### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > MCP server for AI-powered music generation with Strudel.cc
 
+<a href="https://glama.ai/mcp/servers/@williamzujkowski/strudel-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@williamzujkowski/strudel-mcp-server/badge" alt="Strudel Server MCP server" />
+</a>
+
 [![CI](https://github.com/williamzujkowski/strudel-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/strudel-mcp-server/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)]()
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)]()


### PR DESCRIPTION
This PR adds a badge for the [Strudel MCP Server](https://glama.ai/mcp/servers/@williamzujkowski/strudel-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@williamzujkowski/strudel-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@williamzujkowski/strudel-mcp-server/badge" alt="Strudel Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.