### PR TITLE
 Fix: Replace keyboard.type() with insertText() to prevent auto-pairing corruption

### DIFF
--- a/src/StrudelController.ts
+++ b/src/StrudelController.ts
@@ -44,7 +44,11 @@ export class StrudelController {
 
     await this.page.click('.cm-content');
     await this.page.keyboard.press('ControlOrMeta+A');
-    await this.page.keyboard.type(pattern);
+
+    // Use insertText with the full pattern including newlines
+    // insertText doesn't trigger individual keypress events, avoiding auto-pairing
+    // and preserving all whitespace including newlines
+    await this.page.keyboard.insertText(pattern);
 
     return `Pattern written (${pattern.length} chars)`;
   }


### PR DESCRIPTION
## Problem

Hi! Excellent work on this MCP server! 🎉 I've been using it to [automate my Strudel coding workflow](https://github.com/therebelrobot/strudelplay), and I discovered that the `write` tool corrupts patterns by adding extra closing parentheses due to Strudel's CodeMirror auto-pairing feature.

### Example

**Input:**
```javascript
stack(
  sound("bd bd bd bd"),
  sound("~ sd ~ sd")
).room(0.5)
```

**Current Output (corrupted):**
```javascript
stack(sound("bd bd bd bd"),sound("~ sd ~ sd")).room(0.5))
                                                       ^^
                                                    Extra )
```

### Root Cause

The `writePattern()` method in [`StrudelController.ts:42-50`](https://github.com/williamzujkowski/strudel-mcp-server/blob/main/src/StrudelController.ts#L42-L50) uses `page.keyboard.type()`:

```typescript
async writePattern(pattern: string): Promise<string> {
  if (!this.page) throw new Error('Not initialized');

  await this.page.click('.cm-content');
  await this.page.keyboard.press('ControlOrMeta+A');
  await this.page.keyboard.type(pattern);  // ← Problem here

  return `Pattern written (${pattern.length} chars)`;
}
```

When `page.keyboard.type()` simulates typing character-by-character, it triggers CodeMirror's auto-pairing feature. Each opening `(` automatically gets a closing `)` added, then the actual `)` from the pattern creates `))`.

## Solution

Replace `keyboard.type()` with `keyboard.insertText()`:

```typescript
async writePattern(pattern: string): Promise<string> {
  if (!this.page) throw new Error('Not initialized');

  await this.page.click('.cm-content');
  await this.page.keyboard.press('ControlOrMeta+A');
  
  // Use insertText instead of type to avoid triggering auto-pairing
  await this.page.keyboard.insertText(pattern);

  return `Pattern written (${pattern.length} chars)`;
}
```

### Why This Works

- ✅ **No auto-pairing** - `insertText()` doesn't trigger individual keypress events
- ✅ **Exact content** - Patterns written exactly as provided
- ✅ **Faster** - No character-by-character delay
- ✅ **Standard API** - Documented Playwright method

## Testing

I've created a comprehensive test suite to validate the fix.

### Test Repository

Clone my test repository:
```bash
git clone https://github.com/therebelrobot/strudelplay
cd strudelplay
npm install
```

### Test the Bug (main branch)

```bash
# Switch to main branch (uses original MCP server)
git checkout main
git submodule update --init --recursive

# Build MCP server
cd mcp-server && npm install && npm run build && cd ..

# Run test
node test-autocompletion-bug.js
```

**Expected Result:**
```
📊 Test Summary (10 patterns tested):
   ✅ Passed: 6/10
   ❌ Failed: 4/10  ← Bug: Extra parentheses added

❌ FAIL - Functional code mismatch!
Expected: .room(0.5)
Actual:   .room(0.5))  ← Extra closing parenthesis
```

### Test the Fix (fix branch)

```bash
# Switch to fix branch (uses forked MCP server with fix)
git checkout fix/multiline-pattern-corruption
git submodule update --init --recursive

# Rebuild MCP server with fix
cd mcp-server && npm install && npm run build && cd ..

# Run test
node test-autocompletion-bug.js
```

**Expected Result:**
```
📊 Test Summary (10 patterns tested):
   ✅ Passed: 10/10  ← All tests pass!
   ❌ Failed: 0/10

✨ All tests passed! Bug may be fixed.
```

### What the Test Does

The test suite (`test-autocompletion-bug.js`):
- Tests 10 patterns including complex multi-line structures
- Validates functional correctness (whitespace-insensitive comparison)
- Detects extra characters that corrupt the code

**Test patterns include:**
- Single-line: `sound("bd hh")`, `stack(sound("bd"), sound("hh"))`
- Multi-line with nesting: `stack(\n  sound(...),\n  sound(...)\n).room(0.5)`
- Complex techno patterns with multiple methods chained

## Changes

**Modified:** `src/StrudelController.ts`
- Line 47: Changed `await this.page.keyboard.type(pattern)` to `await this.page.keyboard.insertText(pattern)`
- Added comment explaining why insertText is used

## Impact

**Before Fix:**
- 4/10 patterns corrupted with extra parentheses
- All patterns with multi-line `stack()` structures failed
- File watchers and automation workflows broke

**After Fix:**
- 10/10 patterns work correctly
- All pattern structures preserved
- File watchers and automation work reliably

## Backwards Compatibility

✅ Fully backward compatible - all existing functionality preserved, just more reliable

## Related Use Cases

This fix enables:
- File watchers that sync `.strudel` files to browser in real-time
- Automated pattern generation workflows
- Complex multi-line pattern structures
- Any automated tooling using the MCP server

---

Happy to make any adjustments! This fix solves a critical issue for automated workflows.