### PR TITLE
Add Update Button Support for Live Pattern Updates

### DIFF
--- a/src/StrudelController.ts
+++ b/src/StrudelController.ts
@@ -72,6 +72,20 @@ export class StrudelController {
     return 'Playing';
   }
 
+  async update(): Promise<string> {
+    if (!this.page) throw new Error('Not initialized');
+
+    try {
+      await this.page.click('button[title="update"]', { timeout: 1000 });
+    } catch {
+      await this.page.keyboard.press('ControlOrMeta+Enter');
+    }
+
+    await this.page.waitForTimeout(500);
+
+    return 'Pattern updated';
+  }
+
   async stop(): Promise<string> {
     if (!this.page) throw new Error('Not initialized');
 


### PR DESCRIPTION
## Problem

One more addition! The Strudel MCP server previously only supported the `play` command, which was designed to start playback. However, in Strudel's web interface, when a pattern is already playing, it's intended behavior to hit the "update" button instead of a "play" button to update it in realtime. This button is specifically for updating the currently playing pattern without stopping and restarting playback.

Without support for the update button, users had to:
1. Stop the current pattern
2. Modify the code
3. Play again

This workflow interrupted the creative flow and made live coding less seamless when automated.

## Solution

This PR adds a new `update` tool to the MCP server that properly handles live pattern updates:

### Changes Made

#### 1. MCP Server Submodule (`mcp-server/`)

**[`src/StrudelController.ts`](mcp-server/src/StrudelController.ts:78-90)**
- Added `update()` method that clicks the `button[title="update"]` element
- Falls back to `Ctrl+Enter` keyboard shortcut if button not found
- Returns confirmation message "Pattern updated"

**[`src/server/EnhancedMCPServerFixed.ts`](mcp-server/src/server/EnhancedMCPServerFixed.ts:112-116)**
- Added `update` tool definition to the tool list
- Added `update` case to the tool execution handler
- Added `update` to the list of tools requiring initialization
- Tool description: "Update pattern while playing (clicks update button)"

#### 2. Consumer Repository

**[`scripts/test-update.ts`](https://github.com/therebelrobot/strudelplay/blob/feature/add-update-button-support/scripts/test-update.ts)**
- Created comprehensive test script demonstrating the update workflow
- Tests the complete lifecycle: init → write → play → update → stop
- Provides clear output showing each step of the process

### Workflow

The new workflow enables seamless live coding:

1. Initialize Strudel with `init`
2. Write initial pattern with `write`
3. Start playback with `play`
4. Modify pattern with `write` (while still playing)
5. Apply changes with `update` (updates without stopping)
6. Optionally stop with `stop`

## How to Test (in consumer repo)

### Prerequisites

```bash
# Install dependencies if not already done
npm install

# Build the MCP server
cd mcp-server && npm run build && cd ..
```

### Option 1: Automated Test Script

Run the provided test script that demonstrates the complete workflow:

```bash
npx tsx scripts/test-update.ts
```

**Expected Output:**
```
🧪 Testing update functionality...

✅ Connected to MCP server

1️⃣ Initializing Strudel...
✅ Strudel initialized successfully 

2️⃣ Writing initial pattern...
✅ Pattern written (28 chars) 

3️⃣ Starting playback...
✅ Playing 

4️⃣ Writing updated pattern...
✅ Pattern written (38 chars) 

5️⃣ Clicking UPDATE button to apply changes...
✅ Pattern updated 

⏳ Waiting 5 seconds to hear updated pattern...
6️⃣ Stopping playback...
✅ Stopped 

🎉 Update test completed successfully!
```

### Option 2: Manual Testing via MCP Client

You can also test manually by using the MCP tools directly:

```typescript
// 1. Initialize
await client.callTool({ name: 'init', arguments: {} });

// 2. Write initial pattern
await client.callTool({ 
  name: 'write', 
  arguments: { pattern: 'note("c3 eb3 g3").s("piano")' } 
});

// 3. Start playing
await client.callTool({ name: 'play', arguments: {} });

// 4. Write new pattern (while still playing)
await client.callTool({ 
  name: 'write', 
  arguments: { pattern: 'note("c4 d4 e4 g4").s("piano").slow(2)' } 
});

// 5. Update to apply changes
await client.callTool({ name: 'update', arguments: {} });

// 6. Stop when done
await client.callTool({ name: 'stop', arguments: {} });
```

### What to Observe

- **Browser behavior**: When testing, you should see Strudel open in a browser (unless headless mode is enabled)
- **Audio changes**: After calling `update`, you should hear the pattern change from the initial pattern to the updated pattern without any interruption in playback
- **Button interaction**: The update command clicks the actual "update" button in Strudel's UI

## Related

- Addresses the need to programmatically click the "update" button in Strudel
- Complements existing `play` command for initial playback start