### PR TITLE
feat: Add UX improvement tools for better music creation workflow

### DIFF
--- a/src/StrudelController.ts
+++ b/src/StrudelController.ts
@@ -623,6 +623,68 @@ export class StrudelController {
   }
 
   /**
+   * Brings the browser window to the foreground
+   * @returns Success message
+   * @throws {Error} When browser not initialized
+   */
+  async showBrowser(): Promise<string> {
+    if (!this._page) {
+      throw new Error('Browser not initialized. Run init tool first.');
+    }
+
+    try {
+      await this._page.bringToFront();
+      return 'Browser window brought to foreground';
+    } catch (error: any) {
+      this.logger.error('Failed to show browser', error);
+      throw new Error(`Failed to show browser: ${error.message}`);
+    }
+  }
+
+  /**
+   * Takes a screenshot of the current browser state
+   * @param filename - Optional filename for the screenshot
+   * @returns Path to saved screenshot or base64 data
+   * @throws {Error} When browser not initialized
+   */
+  async takeScreenshot(filename?: string): Promise<string> {
+    if (!this._page) {
+      throw new Error('Browser not initialized. Run init tool first.');
+    }
+
+    try {
+      const path = filename || `strudel-screenshot-${Date.now()}.png`;
+      await this._page.screenshot({ path, fullPage: false });
+      return `Screenshot saved to ${path}`;
+    } catch (error: any) {
+      this.logger.error('Failed to take screenshot', error);
+      throw new Error(`Failed to take screenshot: ${error.message}`);
+    }
+  }
+
+  /**
+   * Gets current browser and playback status
+   * @returns Status object with initialization and playback state
+   */
+  getStatus(): {
+    initialized: boolean;
+    playing: boolean;
+    patternLength: number;
+    cacheValid: boolean;
+    errorCount: number;
+    warningCount: number;
+  } {
+    return {
+      initialized: this._page !== null,
+      playing: this.isPlaying,
+      patternLength: this.editorCache.length,
+      cacheValid: this.editorCache.length > 0 && (Date.now() - this.cacheTimestamp) < this.CACHE_TTL,
+      errorCount: this.consoleErrors.length,
+      warningCount: this.consoleWarnings.length
+    };
+  }
+
+  /**
    * Gets detailed browser diagnostics
    * @returns Diagnostic information
    */


### PR DESCRIPTION
## Summary

This PR implements the UX improvement issues from the recent research:

- **#37**: Browser window control - Added `show_browser` and `screenshot` tools for visual feedback
- **#38**: Auto-play option - Added `auto_play` parameter to `write` and `generate_pattern` tools
- **#39**: Status & diagnostics - Added `status`, `diagnostics`, and `show_errors` tools for system visibility
- **#40**: Pattern validation - Added `validate` parameter to `write` with automatic error surfacing
- **#42**: High-level compose - Added `compose` tool for single-command pattern creation workflow

### New Tools

| Tool | Description |
|------|-------------|
| `show_browser` | Bring browser window to foreground for visual feedback |
| `screenshot` | Capture current Strudel editor state |
| `status` | Quick state check (initialized, playing, errors) |
| `diagnostics` | Detailed browser diagnostics (cache, errors, performance) |
| `show_errors` | Display captured console errors/warnings |
| `compose` | Generate, write, and play pattern in one step with auto-init |

### Enhanced Tools

- `write`: Added `auto_play` and `validate` parameters
- `generate_pattern`: Added `auto_play` parameter

### Key Features

- **Auto-initialization**: `compose` tool auto-initializes browser if needed
- **Genre-appropriate defaults**: `compose` uses correct BPM for each genre (e.g., 174 for DnB)
- **Defensive validation**: Gracefully handles missing validation methods
- **Error surfacing**: Pattern validation errors returned before write

## Test plan

- [x] All 704 tests pass
- [x] New tests added for all UX tools (19 tests)
- [x] Build succeeds
- [x] Code follows existing patterns

Closes #37, #38, #39, #40, #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)