### PR TITLE
feat: Add pattern history tools and Docker optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Dependencies
+node_modules
+npm-debug.log
+
+# Build outputs (rebuilt in container)
+dist
+
+# Git
+.git
+.gitignore
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Test files
+src/__tests__
+coverage
+*.test.ts
+jest.config.js
+
+# Documentation
+*.md
+!README.md
+docs
+
+# Development files
+.eslintrc.json
+.prettierrc
+tsconfig.json
+
+# Local config (may have different settings)
+config.json
+
+# Patterns (optional, user-generated)
+patterns
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,48 @@
+# Stage 1: Build
 FROM node:20-alpine AS builder
 
 WORKDIR /app
-COPY package*.json ./
-COPY tsconfig.json ./
-COPY src ./src
 
-# Install dependencies without running prepare hook
+# Copy only package files first (better layer caching)
+COPY package*.json ./
+
+# Install all dependencies (needed for build)
 RUN npm ci --ignore-scripts
 
-# Now build after source is available
+# Copy source and build
+COPY tsconfig.json ./
+COPY src ./src
 RUN npm run build
 
+# Prune dev dependencies to reduce size
+RUN npm prune --production && \
+    rm -rf ~/.npm /tmp/*
+
+# Stage 2: Runtime (smaller image)
 FROM node:20-alpine AS runtime
 
-RUN apk add --no-cache chromium
+# Install Chromium and cleanup in single layer
+RUN apk add --no-cache chromium && \
+    rm -rf /var/cache/apk/*
+
+# Chromium configuration
 ENV PLAYWRIGHT_BROWSERS_PATH=/usr/bin
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true
 ENV CHROMIUM_PATH=/usr/bin/chromium-browser
+ENV NODE_ENV=production
 
 WORKDIR /app
 
+# Copy only production dependencies and built code
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./
 
-# Create patterns directory (doesn't exist in repo)
+# Create patterns directory
 RUN mkdir -p patterns
 
-# Copy config if it exists (optional)
-COPY config.json ./ 2>/dev/null || echo '{"headless":true}' > config.json
+# Create default config for headless mode in container
+RUN echo '{"headless":true}' > config.json
 
 EXPOSE 3000
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An experimental Model Context Protocol (MCP) server that enables Claude to contr
 ## ✨ Features
 
 ### 🎹 Complete Music Control
-- **40+ MCP Tools**: Comprehensive suite for music creation and manipulation
+- **53 MCP Tools**: Comprehensive suite for music creation and manipulation
 - **Real Browser Automation**: Direct control of Strudel.cc through Playwright
 - **Live Audio Analysis**: Real-time frequency analysis via Web Audio API
 - **Pattern Generation**: AI-powered creation across 8+ music genres
@@ -166,6 +166,13 @@ Then ask Claude:
 | `list` | List all patterns |
 | `undo` | Undo last action |
 | `redo` | Redo action |
+
+### Pattern History (3 tools)
+| Tool | Description |
+|------|-------------|
+| `list_history` | Browse pattern history with timestamps and previews |
+| `restore_history` | Restore a previous pattern by ID |
+| `compare_patterns` | Compare two patterns showing line-by-line differences |
 
 ## 🎵 Usage Examples
 


### PR DESCRIPTION
## Summary

- **Pattern History (#41)**: Add tools to browse, restore, and compare pattern versions
- **Docker Optimization (#19)**: Reduce image size with .dockerignore and dep pruning
- **Close outdated PRs**: #25 and #9 are now closed (functionality covered)

## Pattern History Tools (#41)

### `list_history`
Browse pattern history with timestamps and previews:
```json
{
  "count": 5,
  "showing": 5,
  "entries": [
    { "id": 5, "preview": "setcpm(130)\\nstack...", "chars": 245, "action": "write", "timestamp": "2m ago" },
    { "id": 4, "preview": "setcpm(174)\\nstack...", "chars": 312, "action": "write", "timestamp": "5m ago" }
  ]
}
```

### `restore_history`
Restore a previous pattern by ID:
```
> restore_history { "id": 4 }
"Restored pattern from history #4 (5m ago)"
```

### `compare_patterns`
Compare two patterns showing line-by-line differences:
```json
{
  "pattern1": { "id": 4, "chars": 312 },
  "pattern2": { "id": "current", "chars": 245 },
  "diff": ["  setcpm(130)", "- s(\"bd*4\")", "+ s(\"hh*8\")"],
  "summary": { "linesAdded": 2, "linesRemoved": 1, "linesChanged": 3, "charsDiff": -67 }
}
```

## Docker Optimization (#19)

- Add `.dockerignore` to reduce build context
- Better layer caching (copy package*.json first)
- Prune dev dependencies before runtime stage
- Clean up npm cache and temp files
- Set `NODE_ENV=production` for runtime

## Test Plan

- [x] All 712 tests passing
- [x] New history tests cover all acceptance criteria
- [x] Build succeeds

Closes #41
Addresses #19 (Docker optimization - can't verify size without Docker access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)