### PR TITLE
fix(test): stop GenerateExamples test mutating tracked fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 test-results/
 playwright-report/
 playwright/.cache/
+.playwright-mcp/
 
 # Claude/AI Integration artifacts (development tools, not needed in repo)
 .claude-flow/

--- a/src/__tests__/validation/GenerateExamples.test.ts
+++ b/src/__tests__/validation/GenerateExamples.test.ts
@@ -2,13 +2,24 @@ import { PatternGenerator } from '../../services/PatternGenerator';
 import { MusicTheory } from '../../services/MusicTheory';
 import { PatternValidator } from '../../utils/PatternValidator';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 describe('Generate Example Patterns', () => {
   let generator: PatternGenerator;
   let theory: MusicTheory;
   let validator: PatternValidator;
-  const examplesDir = path.join(__dirname, '../../../patterns/examples');
+  // Write to a temp dir — tracked fixtures in patterns/examples/ must not be
+  // mutated by every test run (was producing 14-file timestamp churn).
+  let examplesDir: string;
+
+  beforeAll(() => {
+    examplesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strudel-examples-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(examplesDir, { recursive: true, force: true });
+  });
 
   beforeEach(() => {
     theory = new MusicTheory();


### PR DESCRIPTION
## Summary

- `GenerateExamples.test.ts` wrote into `patterns/examples/<genre>/*.json` with a fresh `timestamp` on every run, dirtying 14 tracked files. Tests must not mutate committed fixtures.
- Switch the test to write into a per-run tmp dir via `mkdtempSync`, cleaned up in `afterAll`. The "all files created" assertion now validates what the test itself produced — which is what it was actually checking.
- Also gitignore `.playwright-mcp/` so Playwright MCP debug logs stop appearing as untracked.

The committed fixtures in `patterns/examples/` are still consumed by `ExampleValidation.browser.test.ts` and `HybridValidation.test.ts`; they stay as-is and can be regenerated explicitly when needed (not as a test side-effect).

## Test plan

- [x] `npx jest src/__tests__/validation/GenerateExamples.test.ts` — all 15 pass
- [x] Full suite: 1519 pass, 20 skipped. The 2 browser failures in `ExampleValidation.browser.test.ts` pre-exist on `main` (tempo detection assertion, unrelated to this change) — separate issue worth filing.
- [x] `git status` clean after running the affected test

🤖 Generated with [Claude Code](https://claude.com/claude-code)