### PR TITLE
test: extract StrudelEngine pure helpers + unit tests (closes #107)

### DIFF
--- a/src/__tests__/unit/StrudelEngineHelpers.test.ts
+++ b/src/__tests__/unit/StrudelEngineHelpers.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for the pure helpers extracted from StrudelEngine (#107).
+ *
+ * These run without @strudel/* — that's the whole point of the split.
+ * If a test here needs to mock anything, it probably belongs in the
+ * integration suite instead.
+ */
+
+import {
+  calculateComplexity,
+  checkCommonIssues,
+  extractBpm,
+  extractFunctionsUsed,
+  getSuggestionsForError,
+  parseErrorLocation,
+} from '../../services/StrudelEngineHelpers';
+
+describe('parseErrorLocation', () => {
+  it('parses acorn-style errors with .loc and .pos', () => {
+    const err = { loc: { line: 3, column: 12 }, pos: 47 };
+    expect(parseErrorLocation(err)).toEqual({ line: 3, column: 12, offset: 47 });
+  });
+
+  it('defaults offset to 0 when acorn .pos is missing', () => {
+    const err = { loc: { line: 1, column: 0 } };
+    expect(parseErrorLocation(err)).toEqual({ line: 1, column: 0, offset: 0 });
+  });
+
+  it('parses Strudel mini errors with .location.start', () => {
+    const err = { location: { start: { line: 2, column: 5, offset: 18 } } };
+    expect(parseErrorLocation(err)).toEqual({ line: 2, column: 5, offset: 18 });
+  });
+
+  it('falls back to message regex when no structured location present', () => {
+    const err = { message: 'Parse error at line 4, column 9' };
+    expect(parseErrorLocation(err)).toEqual({ line: 4, column: 9, offset: 0 });
+  });
+
+  it('matches the message regex case-insensitively', () => {
+    const err = { message: 'Line 7 ... Column 3' };
+    expect(parseErrorLocation(err)).toEqual({ line: 7, column: 3, offset: 0 });
+  });
+
+  it('returns undefined when no shape matches', () => {
+    expect(parseErrorLocation({ message: 'something broke' })).toBeUndefined();
+    expect(parseErrorLocation({})).toBeUndefined();
+    expect(parseErrorLocation(null)).toBeUndefined();
+    expect(parseErrorLocation(undefined)).toBeUndefined();
+  });
+
+  it('prefers acorn .loc over the message regex when both present', () => {
+    const err = {
+      loc: { line: 1, column: 1 },
+      pos: 0,
+      message: 'fallback line 99 column 99',
+    };
+    expect(parseErrorLocation(err)).toEqual({ line: 1, column: 1, offset: 0 });
+  });
+
+  it('prefers Strudel .location over the message regex when both present', () => {
+    const err = {
+      location: { start: { line: 2, column: 2, offset: 2 } },
+      message: 'fallback line 99 column 99',
+    };
+    expect(parseErrorLocation(err)).toEqual({ line: 2, column: 2, offset: 2 });
+  });
+});
+
+describe('getSuggestionsForError', () => {
+  it('suggests bracket/quote checks on unexpected token', () => {
+    const suggestions = getSuggestionsForError('SyntaxError: Unexpected token (');
+    expect(suggestions).toContain('Check for missing quotes, parentheses, or brackets');
+    expect(suggestions).toContain('Ensure all function calls have matching ()');
+  });
+
+  it('quotes the missing identifier on "is not defined"', () => {
+    const suggestions = getSuggestionsForError('ReferenceError: foo is not defined');
+    expect(suggestions).toContain('"foo" is not a known Strudel function');
+    expect(suggestions).toContain(
+      'Check spelling or use a valid function like s(), note(), stack()',
+    );
+  });
+
+  it('handles "is not defined" with no captured name gracefully', () => {
+    // Without the standard "<name> is not defined" pattern there's nothing
+    // to quote, but the lower-case branch still fires. Ensure no throw and
+    // no garbage entries.
+    const suggestions = getSuggestionsForError('is not defined here');
+    expect(suggestions).not.toContain('"undefined" is not a known Strudel function');
+  });
+
+  it('suggests pattern-method check on "not a function"', () => {
+    expect(getSuggestionsForError('x.fast is not a function')).toContain(
+      'Check that you are calling methods on a pattern object',
+    );
+  });
+
+  it('suggests incomplete-bracket check on "unexpected end"', () => {
+    expect(getSuggestionsForError('SyntaxError: Unexpected end of input')).toContain(
+      'Pattern appears incomplete - check for missing closing brackets',
+    );
+  });
+
+  it('returns empty array for unrecognised errors', () => {
+    expect(getSuggestionsForError('something we never see')).toEqual([]);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(getSuggestionsForError('UNEXPECTED TOKEN').length).toBeGreaterThan(0);
+  });
+});
+
+describe('checkCommonIssues', () => {
+  function run(code: string) {
+    const warnings: string[] = [];
+    const suggestions: string[] = [];
+    checkCommonIssues(code, warnings, suggestions);
+    return { warnings, suggestions };
+  }
+
+  it('warns on gain values above 2', () => {
+    const { warnings } = run('s("bd").gain(2.5)');
+    expect(warnings).toContainEqual(expect.stringContaining('High gain value (2.5)'));
+  });
+
+  it('adds a second strong warning on gain values above 5', () => {
+    const { warnings } = run('s("bd").gain(7)');
+    expect(warnings).toContainEqual(expect.stringContaining('High gain value (7)'));
+    expect(warnings).toContainEqual(expect.stringContaining('Dangerous gain value (7)'));
+  });
+
+  it('does not warn on safe gain values', () => {
+    const { warnings } = run('s("bd").gain(0.8)');
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('catches multiple gain calls independently', () => {
+    const { warnings } = run('stack(s("bd").gain(3), s("hh").gain(6))');
+    const gainWarnings = warnings.filter(w => w.includes('gain'));
+    // 3 → one warning; 6 → two warnings (above 2 AND above 5)
+    expect(gainWarnings).toHaveLength(3);
+  });
+
+  it('warns when pattern has no sound source', () => {
+    const { warnings, suggestions } = run('// just a comment');
+    expect(warnings).toContainEqual(expect.stringContaining('may not produce sound'));
+    expect(suggestions).toContainEqual(expect.stringContaining('s("bd")'));
+  });
+
+  it('does not warn about sound when s(), note(), or stack() is present', () => {
+    expect(run('s("bd")').warnings).not.toContainEqual(
+      expect.stringContaining('may not produce sound'),
+    );
+    expect(run('note("c3")').warnings).not.toContainEqual(
+      expect.stringContaining('may not produce sound'),
+    );
+    expect(run('stack(s("bd"), s("hh"))').warnings).not.toContainEqual(
+      expect.stringContaining('may not produce sound'),
+    );
+    expect(run('n("0 2 4")').warnings).not.toContainEqual(
+      expect.stringContaining('may not produce sound'),
+    );
+  });
+
+  it('suggests tempo when setcpm/setbpm absent', () => {
+    expect(run('s("bd")').suggestions).toContainEqual(
+      expect.stringContaining('setcpm(120)'),
+    );
+  });
+
+  it('omits tempo suggestion when any of setcpm/setbpm/cpm/bpm appears', () => {
+    expect(run('setcpm(140); s("bd")').suggestions).not.toContainEqual(
+      expect.stringContaining('setcpm(120)'),
+    );
+    expect(run('setbpm(140); s("bd")').suggestions).not.toContainEqual(
+      expect.stringContaining('setcpm(120)'),
+    );
+  });
+});
+
+describe('extractBpm', () => {
+  it('extracts integer BPM from setcpm', () => {
+    expect(extractBpm('setcpm(140)')).toBe(140);
+  });
+
+  it('extracts fractional BPM from setcpm', () => {
+    expect(extractBpm('setcpm(174.5)')).toBe(174.5);
+  });
+
+  it('tolerates whitespace inside the call', () => {
+    expect(extractBpm('setcpm ( 128 )')).toBe(128);
+  });
+
+  it('returns undefined when setcpm absent', () => {
+    expect(extractBpm('s("bd")')).toBeUndefined();
+  });
+
+  it('returns the first match when called multiple times', () => {
+    expect(extractBpm('setcpm(120); setcpm(140)')).toBe(120);
+  });
+
+  it('does not match setbpm (intentional — Strudel uses setcpm)', () => {
+    expect(extractBpm('setbpm(140)')).toBeUndefined();
+  });
+});
+
+describe('extractFunctionsUsed', () => {
+  it('extracts simple function names', () => {
+    expect(extractFunctionsUsed('s("bd")')).toEqual(['s']);
+  });
+
+  it('deduplicates repeated calls', () => {
+    const result = extractFunctionsUsed('s("bd"); s("hh"); s("sd")');
+    expect(result).toEqual(['s']);
+  });
+
+  it('preserves first-seen order', () => {
+    expect(extractFunctionsUsed('stack(s("bd"), note("c3"))')).toEqual([
+      'stack',
+      's',
+      'note',
+    ]);
+  });
+
+  it('matches method chains', () => {
+    const result = extractFunctionsUsed('s("bd").fast(2).gain(0.8)');
+    expect(result).toEqual(expect.arrayContaining(['s', 'fast', 'gain']));
+  });
+
+  it('ignores PascalCase identifiers (constructor-like)', () => {
+    expect(extractFunctionsUsed('new Pattern()')).toEqual(expect.not.arrayContaining(['Pattern']));
+  });
+
+  it('returns empty array when no function calls present', () => {
+    expect(extractFunctionsUsed('42 + "literal"')).toEqual([]);
+  });
+
+  it('handles identifiers with digits and underscores', () => {
+    const result = extractFunctionsUsed('foo_1("a"); bar2("b")');
+    expect(result).toEqual(['foo_1', 'bar2']);
+  });
+});
+
+describe('calculateComplexity', () => {
+  const minimal = {
+    uniqueValues: [],
+    functionsUsed: [],
+    isStack: false,
+    codeLength: 0,
+  };
+
+  it('returns 0 for empty input', () => {
+    expect(calculateComplexity(minimal, 0)).toBe(0);
+  });
+
+  it('caps at 1 even for very dense patterns', () => {
+    const result = calculateComplexity(
+      {
+        uniqueValues: new Array(50).fill('').map((_, i) => String(i)),
+        functionsUsed: new Array(50).fill('').map((_, i) => `f${i}`),
+        isStack: true,
+        codeLength: 5000,
+      },
+      1000,
+    );
+    expect(result).toBeLessThanOrEqual(1);
+    expect(result).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('weights event density at up to 0.3', () => {
+    const result = calculateComplexity(minimal, 16);
+    expect(result).toBeCloseTo(0.3, 5);
+  });
+
+  it('weights variety (uniqueValues) at up to 0.2', () => {
+    const result = calculateComplexity(
+      { ...minimal, uniqueValues: new Array(8).fill('').map((_, i) => String(i)) },
+      0,
+    );
+    expect(result).toBeCloseTo(0.2, 5);
+  });
+
+  it('weights function count at up to 0.3', () => {
+    const result = calculateComplexity(
+      { ...minimal, functionsUsed: new Array(10).fill('f') },
+      0,
+    );
+    expect(result).toBeCloseTo(0.3, 5);
+  });
+
+  it('adds 0.1 for stack', () => {
+    const result = calculateComplexity({ ...minimal, isStack: true }, 0);
+    expect(result).toBeCloseTo(0.1, 5);
+  });
+
+  it('weights code length at up to ~0.1 for 500-char patterns', () => {
+    const result = calculateComplexity({ ...minimal, codeLength: 500 }, 0);
+    expect(result).toBeCloseTo(0.1, 5);
+  });
+
+  it('uses the simpler estimate when eventCount is undefined', () => {
+    const result = calculateComplexity({
+      uniqueValues: ['ignored', 'when', 'fallback'],
+      functionsUsed: new Array(10).fill('f'),
+      isStack: true,
+      codeLength: 500,
+    });
+    // 0.5 (functions) + 0.3 (length) + 0.2 (stack) = 1.0
+    expect(result).toBeCloseTo(1.0, 5);
+  });
+
+  it('fallback path ignores uniqueValues entirely', () => {
+    const withValues = calculateComplexity({
+      ...minimal,
+      uniqueValues: new Array(20).fill('v'),
+    });
+    const withoutValues = calculateComplexity(minimal);
+    expect(withValues).toBe(withoutValues);
+  });
+
+  it('handles eventCount=0 distinctly from undefined (zero events still calls the weighted path)', () => {
+    const stackOnly = { ...minimal, isStack: true };
+    expect(calculateComplexity(stackOnly, 0)).toBeCloseTo(0.1, 5); // event path: just the stack bonus
+    expect(calculateComplexity(stackOnly)).toBeCloseTo(0.2, 5); // fallback: bigger stack bonus
+  });
+});

--- a/src/services/StrudelEngine.ts
+++ b/src/services/StrudelEngine.ts
@@ -16,6 +16,14 @@
 import * as strudelCore from '@strudel/core';
 import { mini } from '@strudel/mini';
 import { transpiler } from '@strudel/transpiler';
+import {
+  calculateComplexity,
+  checkCommonIssues,
+  extractBpm,
+  extractFunctionsUsed,
+  getSuggestionsForError,
+  parseErrorLocation,
+} from './StrudelEngineHelpers.js';
 
 /**
  * Result of pattern transpilation
@@ -162,8 +170,7 @@ export class StrudelEngine {
         locations: result.locations || [],
       };
     } catch (error: any) {
-      // Parse error location from Strudel/acorn errors
-      const location = this.parseErrorLocation(error);
+      const location = parseErrorLocation(error);
       return {
         success: false,
         error: error.message || 'Transpilation failed',
@@ -201,37 +208,33 @@ export class StrudelEngine {
       };
     }
 
-    // Try transpilation first - catches syntax errors
     const transpileResult = this.transpile(code);
     if (!transpileResult.success) {
       return {
         valid: false,
         errors: [transpileResult.error || 'Syntax error'],
         warnings,
-        suggestions: this.getSuggestionsForError(transpileResult.error || ''),
+        suggestions: getSuggestionsForError(transpileResult.error || ''),
         errorLocation: transpileResult.errorLocation
           ? { line: transpileResult.errorLocation.line, column: transpileResult.errorLocation.column }
           : undefined,
       };
     }
 
-    // Try to evaluate the pattern to catch runtime errors
     try {
       const fn = new Function(...Object.keys(this.context), transpileResult.transpiledCode!);
       const pattern = fn(...Object.values(this.context));
 
-      // Verify it's a valid pattern
       if (!pattern || typeof pattern.queryArc !== 'function') {
         errors.push('Code did not produce a valid pattern');
         suggestions.push('Ensure your code returns a pattern (e.g., s("bd"), note("c3"), stack(...))');
       }
     } catch (error: any) {
       errors.push(`Runtime error: ${error.message}`);
-      suggestions.push(...this.getSuggestionsForError(error.message));
+      suggestions.push(...getSuggestionsForError(error.message));
     }
 
-    // Check for common issues
-    this.checkCommonIssues(code, warnings, suggestions);
+    checkCommonIssues(code, warnings, suggestions);
 
     return {
       valid: errors.length === 0,
@@ -320,41 +323,25 @@ export class StrudelEngine {
    * ```
    */
   analyzePattern(code: string): PatternMetadata {
-    // Default metadata
     const metadata: PatternMetadata = {
       eventsPerCycle: 0,
       uniqueValues: [],
-      usesSound: false,
-      usesNote: false,
-      isStack: false,
-      functionsUsed: [],
+      usesSound: /\bs\s*\(/.test(code) || /\bsound\s*\(/.test(code),
+      usesNote: /\bnote\s*\(/.test(code),
+      isStack: /\bstack\s*\(/.test(code),
+      functionsUsed: extractFunctionsUsed(code),
       complexity: 0,
     };
 
-    // Extract BPM from setcpm
-    const bpmMatch = code.match(/setcpm\s*\(\s*(\d+(?:\.\d+)?)\s*\)/);
-    if (bpmMatch) {
-      metadata.bpm = parseFloat(bpmMatch[1]);
+    const bpm = extractBpm(code);
+    if (bpm !== undefined) {
+      metadata.bpm = bpm;
     }
 
-    // Analyze code structure
-    metadata.usesSound = /\bs\s*\(/.test(code) || /\bsound\s*\(/.test(code);
-    metadata.usesNote = /\bnote\s*\(/.test(code);
-    metadata.isStack = /\bstack\s*\(/.test(code);
-
-    // Extract function names used
-    const funcMatches = code.match(/\b([a-z][a-zA-Z0-9_]*)\s*\(/g);
-    if (funcMatches) {
-      const funcNames = funcMatches.map(m => m.replace(/\s*\($/, ''));
-      metadata.functionsUsed = [...new Set(funcNames)];
-    }
-
-    // Try to query events for detailed analysis
     try {
       const events = this.queryEvents(code, 0, 1);
       metadata.eventsPerCycle = events.length;
 
-      // Extract unique values
       const values = events.map(e => {
         if (typeof e.value === 'object' && e.value !== null) {
           return e.value.s || e.value.note || e.value.n || JSON.stringify(e.value);
@@ -363,23 +350,22 @@ export class StrudelEngine {
       });
       metadata.uniqueValues = [...new Set(values)];
 
-      // Calculate complexity based on various factors
-      const complexityFactors = [
-        Math.min(events.length / 16, 1) * 0.3, // Event density
-        Math.min(metadata.uniqueValues.length / 8, 1) * 0.2, // Variety
-        Math.min(metadata.functionsUsed.length / 10, 1) * 0.3, // Function complexity
-        metadata.isStack ? 0.1 : 0, // Layering
-        (code.length / 500) * 0.1, // Code length
-      ];
-      metadata.complexity = Math.min(complexityFactors.reduce((a, b) => a + b, 0), 1);
-    } catch {
-      // If we can't query events, estimate from code
-      metadata.complexity = Math.min(
-        (metadata.functionsUsed.length / 10) * 0.5 +
-        (code.length / 500) * 0.3 +
-        (metadata.isStack ? 0.2 : 0),
-        1
+      metadata.complexity = calculateComplexity(
+        {
+          uniqueValues: metadata.uniqueValues,
+          functionsUsed: metadata.functionsUsed,
+          isStack: metadata.isStack,
+          codeLength: code.length,
+        },
+        events.length,
       );
+    } catch {
+      metadata.complexity = calculateComplexity({
+        uniqueValues: metadata.uniqueValues,
+        functionsUsed: metadata.functionsUsed,
+        isStack: metadata.isStack,
+        codeLength: code.length,
+      });
     }
 
     return metadata;
@@ -398,99 +384,7 @@ export class StrudelEngine {
     };
   }
 
-  /**
-   * Parse error location from various error formats
-   */
-  private parseErrorLocation(error: any): { line: number; column: number; offset: number } | undefined {
-    // Acorn-style location
-    if (error.loc) {
-      return {
-        line: error.loc.line,
-        column: error.loc.column,
-        offset: error.pos || 0,
-      };
-    }
-
-    // Strudel mini SyntaxError
-    if (error.location) {
-      return {
-        line: error.location.start.line,
-        column: error.location.start.column,
-        offset: error.location.start.offset,
-      };
-    }
-
-    // Try to parse from message
-    const lineColMatch = error.message?.match(/line\s*(\d+).*column\s*(\d+)/i);
-    if (lineColMatch) {
-      return {
-        line: parseInt(lineColMatch[1]),
-        column: parseInt(lineColMatch[2]),
-        offset: 0,
-      };
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Get suggestions based on error message
-   */
-  private getSuggestionsForError(error: string): string[] {
-    const suggestions: string[] = [];
-    const lowerError = error.toLowerCase();
-
-    if (lowerError.includes('unexpected token')) {
-      suggestions.push('Check for missing quotes, parentheses, or brackets');
-      suggestions.push('Ensure all function calls have matching ()');
-    }
-
-    if (lowerError.includes('is not defined')) {
-      const match = error.match(/(\w+) is not defined/);
-      if (match) {
-        suggestions.push(`"${match[1]}" is not a known Strudel function`);
-        suggestions.push('Check spelling or use a valid function like s(), note(), stack()');
-      }
-    }
-
-    if (lowerError.includes('not a function')) {
-      suggestions.push('Check that you are calling methods on a pattern object');
-    }
-
-    if (lowerError.includes('unexpected end')) {
-      suggestions.push('Pattern appears incomplete - check for missing closing brackets');
-    }
-
-    return suggestions;
-  }
-
-  /**
-   * Check for common issues in pattern code
-   */
-  private checkCommonIssues(code: string, warnings: string[], suggestions: string[]): void {
-    // Check for high gain values
-    const gainMatches = code.match(/\.gain\s*\(\s*(\d+(?:\.\d+)?)\s*\)/g);
-    if (gainMatches) {
-      for (const match of gainMatches) {
-        const value = parseFloat(match.match(/(\d+(?:\.\d+)?)/)?.[1] || '0');
-        if (value > 2) {
-          warnings.push(`High gain value (${value}) may cause distortion`);
-        }
-        if (value > 5) {
-          warnings.push(`Dangerous gain value (${value}) - consider reducing to 2 or less`);
-        }
-      }
-    }
-
-    // Check for missing sound-producing functions
-    if (!/\b(s|sound|note|n)\s*\(/.test(code) && !/\bstack\s*\(/.test(code)) {
-      warnings.push('Pattern may not produce sound - no s(), note(), or stack() found');
-      suggestions.push('Add a sound source like s("bd") or note("c3")');
-    }
-
-    // Suggest tempo if not set
-    if (!/setcpm|setbpm|cpm|bpm/.test(code)) {
-      suggestions.push('Consider setting tempo with setcpm(120)');
-    }
-  }
+  // parseErrorLocation / getSuggestionsForError / checkCommonIssues
+  // moved to StrudelEngineHelpers.ts (#107) so they can be unit-tested
+  // directly without the @strudel/* ESM/CJS jest mismatch.
 }

--- a/src/services/StrudelEngineHelpers.ts
+++ b/src/services/StrudelEngineHelpers.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure helpers extracted from StrudelEngine for direct unit testing.
+ *
+ * StrudelEngine.ts imports @strudel/* packages, which ship as ESM and
+ * fight Jest's CJS loader (see #107). Helpers that don't touch @strudel
+ * — string parsing, regex extraction, scoring — live here so they can
+ * be tested without the ESM workaround dance.
+ *
+ * @module services/StrudelEngineHelpers
+ */
+
+/** Error location shape shared by transpile / validate results. */
+export interface ErrorLocation {
+  line: number;
+  column: number;
+  offset: number;
+}
+
+/**
+ * Pattern metadata used by complexity scoring. Mirrors the relevant
+ * subset of PatternMetadata in StrudelEngine.ts so this module stays
+ * self-contained.
+ */
+export interface ComplexityInput {
+  uniqueValues: string[];
+  functionsUsed: string[];
+  isStack: boolean;
+  codeLength: number;
+}
+
+/**
+ * Parse an error location from the assortment of shapes the Strudel
+ * stack produces:
+ *   - acorn:  { loc: { line, column }, pos }
+ *   - mini:   { location: { start: { line, column, offset } } }
+ *   - other:  message string containing "line N ... column N"
+ * Returns undefined if no shape matches — callers should treat that
+ * as "location unknown" rather than an error.
+ */
+export function parseErrorLocation(error: any): ErrorLocation | undefined {
+  if (error?.loc) {
+    return {
+      line: error.loc.line,
+      column: error.loc.column,
+      offset: error.pos ?? 0,
+    };
+  }
+
+  if (error?.location?.start) {
+    return {
+      line: error.location.start.line,
+      column: error.location.start.column,
+      offset: error.location.start.offset,
+    };
+  }
+
+  const lineColMatch = error?.message?.match(/line\s*(\d+).*column\s*(\d+)/i);
+  if (lineColMatch) {
+    return {
+      line: parseInt(lineColMatch[1], 10),
+      column: parseInt(lineColMatch[2], 10),
+      offset: 0,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Produce actionable suggestions for an error message. Recognises four
+ * common error families: unexpected token, undefined name, not-a-fn,
+ * unexpected end of input. Returns an empty array for anything else
+ * (callers should still surface the raw error).
+ */
+export function getSuggestionsForError(error: string): string[] {
+  const suggestions: string[] = [];
+  const lowerError = error.toLowerCase();
+
+  if (lowerError.includes('unexpected token')) {
+    suggestions.push('Check for missing quotes, parentheses, or brackets');
+    suggestions.push('Ensure all function calls have matching ()');
+  }
+
+  if (lowerError.includes('is not defined')) {
+    const match = error.match(/(\w+) is not defined/);
+    if (match) {
+      suggestions.push(`"${match[1]}" is not a known Strudel function`);
+      suggestions.push('Check spelling or use a valid function like s(), note(), stack()');
+    }
+  }
+
+  if (lowerError.includes('not a function')) {
+    suggestions.push('Check that you are calling methods on a pattern object');
+  }
+
+  if (lowerError.includes('unexpected end')) {
+    suggestions.push('Pattern appears incomplete - check for missing closing brackets');
+  }
+
+  return suggestions;
+}
+
+/**
+ * Append warnings/suggestions for common pattern-code issues:
+ *   - gain values above safe thresholds (2.0 warn, 5.0 strong warn)
+ *   - patterns with no sound-producing call (s/sound/note/n/stack)
+ *   - patterns with no tempo set (setcpm/setbpm/cpm/bpm)
+ *
+ * Mutates the passed arrays in-place to match the calling convention
+ * in StrudelEngine.validate(). Returns nothing.
+ */
+export function checkCommonIssues(
+  code: string,
+  warnings: string[],
+  suggestions: string[],
+): void {
+  const gainMatches = code.match(/\.gain\s*\(\s*(\d+(?:\.\d+)?)\s*\)/g);
+  if (gainMatches) {
+    for (const match of gainMatches) {
+      const value = parseFloat(match.match(/(\d+(?:\.\d+)?)/)?.[1] || '0');
+      if (value > 2) {
+        warnings.push(`High gain value (${value}) may cause distortion`);
+      }
+      if (value > 5) {
+        warnings.push(`Dangerous gain value (${value}) - consider reducing to 2 or less`);
+      }
+    }
+  }
+
+  if (!/\b(s|sound|note|n)\s*\(/.test(code) && !/\bstack\s*\(/.test(code)) {
+    warnings.push('Pattern may not produce sound - no s(), note(), or stack() found');
+    suggestions.push('Add a sound source like s("bd") or note("c3")');
+  }
+
+  if (!/setcpm|setbpm|cpm|bpm/.test(code)) {
+    suggestions.push('Consider setting tempo with setcpm(120)');
+  }
+}
+
+/**
+ * Extract BPM from a `setcpm(<number>)` call. Returns undefined when
+ * absent — Strudel's default tempo is documented elsewhere; this helper
+ * stays narrow (no fallback) so callers can distinguish "not set" from
+ * "set to default".
+ */
+export function extractBpm(code: string): number | undefined {
+  const match = code.match(/setcpm\s*\(\s*(\d+(?:\.\d+)?)\s*\)/);
+  return match ? parseFloat(match[1]) : undefined;
+}
+
+/**
+ * Extract unique function-call names from pattern code. Matches the
+ * lowercase-starting identifier immediately before `(` — same heuristic
+ * Strudel patterns follow (s, note, stack, fast, ...). Returns names in
+ * first-seen order, deduplicated.
+ */
+export function extractFunctionsUsed(code: string): string[] {
+  const matches = code.match(/\b([a-z][a-zA-Z0-9_]*)\s*\(/g);
+  if (!matches) return [];
+  const names = matches.map(m => m.replace(/\s*\($/, ''));
+  return [...new Set(names)];
+}
+
+/**
+ * Score pattern complexity on a 0..1 scale. Two paths:
+ *   - with events: weighted sum across event density, value variety,
+ *     function count, stack bonus, code length
+ *   - without events (e.g. unqueryable pattern): fall back to a simpler
+ *     code-only estimate so we still return something useful
+ *
+ * Weights and caps are calibrated to keep typical patterns around 0.3–0.7
+ * with truly dense patterns reaching 1.0. Changing them shifts every
+ * downstream "complexity" report — bump cautiously.
+ */
+export function calculateComplexity(
+  input: ComplexityInput,
+  eventCount?: number,
+): number {
+  if (eventCount === undefined) {
+    return Math.min(
+      (input.functionsUsed.length / 10) * 0.5 +
+      (input.codeLength / 500) * 0.3 +
+      (input.isStack ? 0.2 : 0),
+      1,
+    );
+  }
+
+  const factors = [
+    Math.min(eventCount / 16, 1) * 0.3,
+    Math.min(input.uniqueValues.length / 8, 1) * 0.2,
+    Math.min(input.functionsUsed.length / 10, 1) * 0.3,
+    input.isStack ? 0.1 : 0,
+    (input.codeLength / 500) * 0.1,
+  ];
+  return Math.min(factors.reduce((a, b) => a + b, 0), 1);
+}


### PR DESCRIPTION
Closes #107 — the last open item under the #115 coverage epic.

## The blocker, and the fix

\`StrudelEngine.ts\` can't be loaded by Jest because \`@strudel/*\` packages are ESM and ts-jest emits CJS that can't consume \`fraction.js\` as ESM (see #107 for the full incident write-up). Existing unit tests all use \`jest.mock()\` — they test the mock, not the real code. That's why \`StrudelEngine.ts\` shows 0% unit coverage.

Per #107's recommended refactor: extract the six pure helpers to a new module that **doesn't import @strudel**, so Jest can load it directly.

## What moves

| Helper | What it does |
|---|---|
| \`parseErrorLocation\` | Normalises acorn / Strudel-mini / message-regex error shapes |
| \`getSuggestionsForError\` | Maps error messages to actionable suggestions |
| \`checkCommonIssues\` | Gain warnings, missing sound source, missing tempo |
| \`extractBpm\` | Regex for \`setcpm(<n>)\` |
| \`extractFunctionsUsed\` | Function-name regex with dedup |
| \`calculateComplexity\` | 0..1 scoring with weighted-event and code-only paths |

\`StrudelEngine.ts\` delegates to them. The \`@strudel\`-touching methods (\`transpile\`, \`validate\`, \`queryEvents\`, \`compile\`) stay put and remain covered by the integration tests.

## Coverage

\`src/services/StrudelEngineHelpers.ts\`:
- **100% statements**
- **100% functions**
- **96.29% branches** (single uncovered branch is the parseFloat-fallback path in checkCommonIssues; not load-bearing)

Across 46 new tests.

## Test plan

- [x] \`npx jest src/__tests__/unit/StrudelEngineHelpers.test.ts --coverage\` — 46 pass, ≥95% on every metric
- [x] \`npx jest --testPathIgnorePatterns=browser\` — 1536 pass (was 1490), 20 skipped, 0 fail
- [x] \`tsc --noEmit\` clean
- [x] AC ≥80% statement coverage on the testable surface — exceeded (100%)

## Coverage areas

- \`parseErrorLocation\` — acorn shape, Strudel-mini shape, message-regex fallback, undefined when nothing matches, precedence when multiple shapes are present
- \`getSuggestionsForError\` — each of the four recognised error families, empty result for unknown errors, case-insensitive matching
- \`checkCommonIssues\` — gain thresholds at 2.0 and 5.0, multiple gain calls, sound-source detection for s/sound/note/n/stack, tempo suggestion suppression
- \`extractBpm\` / \`extractFunctionsUsed\` — whitespace tolerance, dedup, first-seen ordering, empty input
- \`calculateComplexity\` — each weighted factor at maximum, cap at 1.0, fallback path when eventCount is undefined, eventCount=0 vs undefined distinction

## Out of scope

- Unit-testing the \`@strudel\`-dependent methods. That needs a \`jest.projects\` config or an ESM-enabled workspace — file a separate issue if helper extraction doesn't give us enough signal in practice.

This is the last item in the #115 coverage epic — all four sub-issues (#105, #106, #107, #112) will be closed when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)