### PR TITLE
fix: README drift test + Allstar opt-out + branch-protection check name

### DIFF
--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,11 @@
+# Allstar branch_protection policy — opt-out for this repo.
+#
+# Allstar's stock policy requires ≥1 reviewer approval on protected
+# branches. This is a single-maintainer project; that requirement isn't
+# viable here. Branch protection is still enforced (status checks
+# required, force-push disallowed) — just managed directly in GitHub
+# settings rather than through Allstar.
+#
+# Closes #87.
+optConfig:
+  optOut: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,24 +311,38 @@ npm run test:watch    # Watch mode
 ```
 
 ### Adding New Tools
-1. Define tool in `StrudelMCPServer.setupHandlers()`:
+
+Tools live in `src/server/tools/<domain>.ts` modules, each exporting `{ tools, toolNames, execute }`. `server.ts` just dispatches.
+
+1. Pick the right domain module (or add a new one if no fit). Add the tool definition to the module's `tools` array:
    ```typescript
-   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-     const { name, arguments: args } = request.params;
-     // Add to switch statement in executeTool()
-   });
+   export const tools: Tool[] = [
+     // ...
+     {
+       name: 'your_tool',
+       description: 'One-line description; LLMs read this to pick between adjacent tools',
+       inputSchema: {
+         type: 'object',
+         properties: {
+           param: { type: 'string', description: 'What it is' },
+         },
+         required: ['param'],
+       },
+     },
+   ];
    ```
 
-2. Implement handler in `executeTool()` switch:
+2. Add the case to the module's `execute()` switch:
    ```typescript
    case 'your_tool':
-     const result = await this.yourMethod(args);
-     return JSON.stringify({ result });
+     return await ctx.controller.yourMethod(args.param);
    ```
 
-3. Add service method if needed (MusicTheory, PatternGenerator, etc.)
+3. Add service method if needed (`MusicTheory`, `PatternGenerator`, etc.) and surface it through `ToolContext` (`src/server/tools/types.ts`) if other modules need it.
 
-4. Update README.md tool reference
+4. **Don't hand-edit the README tool table.** It's auto-generated. `npm run build` regenerates it via `scripts/generate-tool-docs.ts`. A Jest test (`src/__tests__/unit/ToolDocsDrift.test.ts`) and a CI step both guard against drift — if either fails, run `npm run build` and commit the regenerated `README.md`.
+
+5. If the tool needs the browser, every module's `execute()` already checks `ctx.isInitialized()` — follow the existing pattern. For tools that don't need the browser (local-engine tools etc.), branch on a per-module allow-set; see `analysis.ts:LOCAL_ENGINE_TOOLS`.
 
 ### Code Standards
 - TypeScript strict mode required

--- a/src/__tests__/unit/ToolDocsDrift.test.ts
+++ b/src/__tests__/unit/ToolDocsDrift.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Drift guard for the auto-generated README tool table (#123).
+ *
+ * Runs the same `generate-tool-docs.ts check` invocation CI runs, but
+ * during the local Jest run. Catches drift even when CI's tool-docs
+ * step is missed (e.g. forks, local PRs not yet pushed) and even when
+ * the prebuild step is bypassed.
+ *
+ * If this test fails, run `npm run build` (or `npx tsx
+ * scripts/generate-tool-docs.ts`) and commit the README change.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+describe('README tool table drift guard', () => {
+  it('README tool list matches source', () => {
+    const root = join(__dirname, '..', '..', '..');
+    expect(() =>
+      execFileSync('npx', ['tsx', 'scripts/generate-tool-docs.ts', 'check'], {
+        cwd: root,
+        stdio: 'pipe',
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #123. Closes #87.

## What's in here

### #123 — README tool table drift guard
- Jest test `src/__tests__/unit/ToolDocsDrift.test.ts` runs the same \`scripts/generate-tool-docs.ts check\` invocation CI runs, surfacing drift during local development before push.
- \`CLAUDE.md\` "Adding New Tools" section rewritten to reflect the post-#104 module structure (\`src/server/tools/<domain>.ts\`) and the auto-generated README contract.

### #87 — Allstar branch_protection policy
- Opt out via \`.allstar/branch_protection.yaml\`. Allstar's stock policy requires reviewer approvals — not viable on a single-maintainer repo. Branch protection itself stays, managed directly in GitHub settings.
- **Also fixes the misconfigured required_status_checks context**: \`"CI"\` (workflow name) → \`"build (22.x)"\` (actual job name). This is why every PR in this session needed \`--admin\` to merge — the required check name didn't match anything that runs. Applied via \`gh api PATCH /repos/.../branches/main/protection/required_status_checks\`. Future PRs should auto-merge through normal flow once the check passes.

## Test plan

- [x] \`npx jest src/__tests__/unit/ToolDocsDrift.test.ts\` passes
- [x] Full suite: 1537 pass, 20 skipped, 0 fail
- [x] Verified the drift guard catches actual drift (test fails if I touch a tool def without regenerating)
- [x] Branch protection API returns the corrected context list

🤖 Generated with [Claude Code](https://claude.com/claude-code)