### PR TITLE
feat: expose MCP resources for examples / patterns / styles / tool docs

### DIFF
--- a/src/__tests__/unit/Resources.test.ts
+++ b/src/__tests__/unit/Resources.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the MCP resources module (#131).
+ *
+ * Calls readResource directly with a stub PatternStore and the bundled
+ * examples directory. The protocol-level wiring (capability advertisement,
+ * ListResourcesRequestSchema / ReadResourceRequestSchema handlers in
+ * server.ts) is exercised by the existing MCP integration tests.
+ */
+
+import { join } from 'node:path';
+import { isResourceUri, readResource, resources } from '../../server/resources';
+
+const stubStore = {
+  list: async () => [
+    {
+      name: 'demo',
+      content: 's("bd hh sd hh")',
+      tags: ['demo'],
+      timestamp: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+} as any;
+
+const ctx = {
+  store: stubStore,
+  examplesDir: join(__dirname, '..', '..', '..', 'patterns', 'examples'),
+};
+
+describe('MCP resources', () => {
+  it('advertises exactly four resources', () => {
+    expect(resources).toHaveLength(4);
+    const uris = resources.map(r => r.uri);
+    expect(uris).toEqual(
+      expect.arrayContaining([
+        'strudel://examples',
+        'strudel://patterns',
+        'strudel://styles',
+        'strudel://docs/tools',
+      ]),
+    );
+  });
+
+  it('every resource declares JSON mime type', () => {
+    for (const r of resources) {
+      expect(r.mimeType).toBe('application/json');
+    }
+  });
+
+  it('isResourceUri recognises advertised URIs and rejects others', () => {
+    expect(isResourceUri('strudel://examples')).toBe(true);
+    expect(isResourceUri('strudel://unknown')).toBe(false);
+    expect(isResourceUri('http://example.com')).toBe(false);
+  });
+
+  describe('strudel://examples', () => {
+    it('returns the bundled example catalog', async () => {
+      const result = await readResource('strudel://examples', ctx);
+      expect(result.uri).toBe('strudel://examples');
+      expect(result.mimeType).toBe('application/json');
+      const data = JSON.parse(result.text);
+      expect(data.count).toBeGreaterThan(0);
+      expect(Array.isArray(data.examples)).toBe(true);
+      const first = data.examples[0];
+      expect(first).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          genre: expect.any(String),
+        }),
+      );
+    });
+
+    it('sorts examples by genre then name', async () => {
+      const result = await readResource('strudel://examples', ctx);
+      const data = JSON.parse(result.text);
+      const sorted = [...data.examples].sort(
+        (a: any, b: any) => a.genre.localeCompare(b.genre) || a.name.localeCompare(b.name),
+      );
+      expect(data.examples).toEqual(sorted);
+    });
+  });
+
+  describe('strudel://patterns', () => {
+    it('returns saved patterns from the store with content preview', async () => {
+      const result = await readResource('strudel://patterns', ctx);
+      const data = JSON.parse(result.text);
+      expect(data.count).toBe(1);
+      expect(data.patterns[0]).toEqual(
+        expect.objectContaining({
+          name: 'demo',
+          tags: ['demo'],
+          contentPreview: 's("bd hh sd hh")',
+        }),
+      );
+    });
+
+    it('truncates long pattern bodies in the preview', async () => {
+      const longContent = 'x'.repeat(500);
+      const ctxLong = {
+        ...ctx,
+        store: {
+          list: async () => [
+            { name: 'long', content: longContent, tags: [], timestamp: '' },
+          ],
+        } as any,
+      };
+      const result = await readResource('strudel://patterns', ctxLong);
+      const data = JSON.parse(result.text);
+      expect(data.patterns[0].contentPreview).toHaveLength(203); // 200 chars + '...'
+      expect(data.patterns[0].contentPreview.endsWith('...')).toBe(true);
+    });
+  });
+
+  describe('strudel://styles', () => {
+    it('returns supported styles with default BPMs', async () => {
+      const result = await readResource('strudel://styles', ctx);
+      const data = JSON.parse(result.text);
+      expect(data.count).toBeGreaterThanOrEqual(15);
+      const techno = data.styles.find((s: any) => s.name === 'techno');
+      expect(techno).toEqual({ name: 'techno', defaultBpm: 130 });
+      const dnb = data.styles.find((s: any) => s.name === 'dnb');
+      expect(dnb).toEqual({ name: 'dnb', defaultBpm: 174 });
+    });
+
+    it('sorts styles alphabetically', async () => {
+      const result = await readResource('strudel://styles', ctx);
+      const data = JSON.parse(result.text);
+      const names = data.styles.map((s: any) => s.name);
+      expect(names).toEqual([...names].sort());
+    });
+  });
+
+  describe('strudel://docs/tools', () => {
+    it('returns every registered tool with a description', async () => {
+      const result = await readResource('strudel://docs/tools', ctx);
+      const data = JSON.parse(result.text);
+      // 70 tool defs after #133 + the unlisted `init` we prepend = 71
+      expect(data.count).toBeGreaterThanOrEqual(70);
+      const initTool = data.tools.find((t: any) => t.name === 'init');
+      expect(initTool).toBeDefined();
+      const compose = data.tools.find((t: any) => t.name === 'compose');
+      expect(compose?.description).toContain('Generate, write, and play');
+    });
+
+    it('includes the four previously orphan local-engine tools', async () => {
+      const result = await readResource('strudel://docs/tools', ctx);
+      const data = JSON.parse(result.text);
+      const names = data.tools.map((t: any) => t.name);
+      expect(names).toEqual(expect.arrayContaining([
+        'validate_pattern_local',
+        'analyze_pattern_local',
+        'query_pattern_events',
+        'transpile_pattern',
+      ]));
+    });
+  });
+
+  it('throws on unknown URI', async () => {
+    await expect(readResource('strudel://nope', ctx)).rejects.toThrow(/Unknown resource URI/);
+  });
+});

--- a/src/server/resources.ts
+++ b/src/server/resources.ts
@@ -1,0 +1,212 @@
+/**
+ * MCP resources — read-only catalogs the server exposes alongside tools.
+ *
+ * From #131 (originated as finding #6 in @nareto's audit #127): an agent
+ * shouldn't have to spend tool calls just to discover what bundled
+ * patterns exist or which styles the generator accepts. Surface those
+ * catalogs as MCP resources so they can be listed once and reasoned
+ * about without round-trips.
+ *
+ * Four resources:
+ *   strudel://examples              — bundled patterns under patterns/examples
+ *   strudel://patterns              — user-saved patterns from PatternStore
+ *   strudel://styles                — supported genres + default BPM
+ *   strudel://docs/tools            — tool quick-reference, one line each
+ *
+ * All payloads are JSON text. URIs are stable; content for examples and
+ * styles is bundled with the build and effectively immutable per release.
+ * Patterns is the only one that mutates at runtime.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join, basename } from 'node:path';
+import type { PatternStore } from '../PatternStore.js';
+import { diagnosticsModule } from './tools/diagnostics.js';
+import { playbackModule } from './tools/playback.js';
+import { storageModule } from './tools/storage.js';
+import { historyModule } from './tools/history.js';
+import { analysisModule } from './tools/analysis.js';
+import { editorModule } from './tools/editor.js';
+import { transformModule } from './tools/transform.js';
+import { generateModule } from './tools/generate.js';
+import { sessionModule } from './tools/session.js';
+import { captureModule } from './tools/capture.js';
+import { aiModule } from './tools/ai.js';
+import { composeModule } from './tools/compose.js';
+
+export interface ResourceContext {
+  store: PatternStore;
+  examplesDir: string;
+}
+
+export interface ResourceDescriptor {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export const resources: ResourceDescriptor[] = [
+  {
+    uri: 'strudel://examples',
+    name: 'Bundled example patterns',
+    description: 'Curated example patterns shipped with the server, organised by genre',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'strudel://patterns',
+    name: 'Saved patterns',
+    description: 'Patterns saved by the user via the `save` tool, with tags and timestamps',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'strudel://styles',
+    name: 'Supported styles',
+    description: 'Genres the generator accepts, with their default tempos',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'strudel://docs/tools',
+    name: 'Tool quick-reference',
+    description: 'Compact list of every registered MCP tool with a one-line description',
+    mimeType: 'application/json',
+  },
+];
+
+const resourceUris = new Set(resources.map(r => r.uri));
+
+export function isResourceUri(uri: string): boolean {
+  return resourceUris.has(uri);
+}
+
+/**
+ * Default tempos for the supported style set. Kept in sync with
+ * compose.ts:TEMPO_BY_STYLE — both grow together when a new genre
+ * lands. Future cleanup (#120 aftermath): single source of truth.
+ */
+const STYLE_DEFAULTS: Record<string, number> = {
+  techno: 130,
+  house: 125,
+  dnb: 174,
+  ambient: 80,
+  trap: 140,
+  jungle: 160,
+  jazz: 110,
+  experimental: 120,
+  dubstep: 140,
+  trance: 138,
+  breakbeat: 130,
+  garage: 130,
+  electro: 128,
+  downtempo: 90,
+  idm: 115,
+};
+
+const TOOL_MODULES = [
+  editorModule,
+  playbackModule,
+  transformModule,
+  generateModule,
+  analysisModule,
+  storageModule,
+  historyModule,
+  diagnosticsModule,
+  composeModule,
+  aiModule,
+  captureModule,
+  sessionModule,
+];
+
+async function readExamples(examplesDir: string): Promise<unknown> {
+  const entries = await fs.readdir(examplesDir, { withFileTypes: true });
+  const genres = entries.filter(e => e.isDirectory()).map(e => e.name);
+
+  const items: Array<{
+    name: string;
+    genre: string;
+    bpm: number;
+    key: string;
+    tags: string[];
+    description?: string;
+  }> = [];
+
+  for (const genre of genres) {
+    const dir = join(examplesDir, genre);
+    const files = await fs.readdir(dir);
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const raw = await fs.readFile(join(dir, file), 'utf-8');
+        const data = JSON.parse(raw);
+        items.push({
+          name: data.name ?? basename(file, '.json'),
+          genre: data.genre ?? genre,
+          bpm: data.bpm,
+          key: data.key,
+          tags: data.tags ?? [],
+          description: data.description,
+        });
+      } catch {
+        // Skip malformed example files rather than failing the whole list.
+      }
+    }
+  }
+
+  items.sort((a, b) => a.genre.localeCompare(b.genre) || a.name.localeCompare(b.name));
+  return { count: items.length, examples: items };
+}
+
+async function readSavedPatterns(store: PatternStore): Promise<unknown> {
+  const patterns = await store.list();
+  const items = patterns.map(p => ({
+    name: p.name,
+    tags: p.tags,
+    timestamp: p.timestamp,
+    contentPreview: p.content.length > 200 ? p.content.slice(0, 200) + '...' : p.content,
+  }));
+  return { count: items.length, patterns: items };
+}
+
+function readStyles(): unknown {
+  const items = Object.entries(STYLE_DEFAULTS)
+    .map(([name, defaultBpm]) => ({ name, defaultBpm }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return { count: items.length, styles: items };
+}
+
+function readToolDocs(): unknown {
+  const items = TOOL_MODULES.flatMap(m =>
+    m.tools.map(t => ({ name: t.name, description: t.description })),
+  );
+  items.unshift({ name: 'init', description: 'Initialize Strudel in browser' });
+  items.sort((a, b) => a.name.localeCompare(b.name));
+  return { count: items.length, tools: items };
+}
+
+export async function readResource(
+  uri: string,
+  ctx: ResourceContext,
+): Promise<{ uri: string; mimeType: string; text: string }> {
+  let data: unknown;
+  switch (uri) {
+    case 'strudel://examples':
+      data = await readExamples(ctx.examplesDir);
+      break;
+    case 'strudel://patterns':
+      data = await readSavedPatterns(ctx.store);
+      break;
+    case 'strudel://styles':
+      data = readStyles();
+      break;
+    case 'strudel://docs/tools':
+      data = readToolDocs();
+      break;
+    default:
+      throw new Error(`Unknown resource URI: ${uri}`);
+  }
+  return {
+    uri,
+    mimeType: 'application/json',
+    text: JSON.stringify(data, null, 2),
+  };
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2,7 +2,9 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { StrudelController } from '../StrudelController.js';
@@ -30,6 +32,8 @@ import { captureModule } from './tools/capture.js';
 import { aiModule } from './tools/ai.js';
 import { composeModule } from './tools/compose.js';
 import type { ToolContext, HistoryEntry } from './tools/types.js';
+import { readResource, resources as mcpResources } from './resources.js';
+import { join } from 'node:path';
 
 const configPath = './config.json';
 const config = existsSync(configPath)
@@ -69,6 +73,7 @@ export class StrudelMCPServer {
       {
         capabilities: {
           tools: {},
+          resources: {},
         },
       }
     );
@@ -140,6 +145,27 @@ export class StrudelMCPServer {
             text: `Error: ${message}`
           }],
         };
+      }
+    });
+
+    // MCP resources — read-only catalogs (#131). Resource handlers stay
+    // here in server.ts because they're protocol surface, not tool calls.
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: mcpResources,
+    }));
+
+    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const uri = request.params.uri;
+      try {
+        const content = await readResource(uri, {
+          store: this.store,
+          examplesDir: join(process.cwd(), 'patterns', 'examples'),
+        });
+        return { contents: [content] };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(`Resource read failed: ${uri}`, { error: message });
+        throw error;
       }
     });
   }


### PR DESCRIPTION
Closes #131. Advances #127 (finding #6).

## Summary

Adds four read-only catalogs as MCP resources so agents can list them once and reason about them without burning tool calls:

| URI | Returns |
|---|---|
| \`strudel://examples\` | Bundled examples under \`patterns/examples\` |
| \`strudel://patterns\` | User-saved patterns from \`PatternStore\` (with content preview) |
| \`strudel://styles\` | Supported genres + default tempos |
| \`strudel://docs/tools\` | Every registered tool, one line each |

Server now advertises the \`resources\` capability alongside \`tools\`. \`ListResourcesRequestSchema\` and \`ReadResourceRequestSchema\` handlers live in \`server.ts\` (protocol surface, not tool calls). Definitions and read logic live in \`src/server/resources.ts\`.

## Test plan

- [x] 12 unit tests in \`src/__tests__/unit/Resources.test.ts\` (each URI's contract + URI gatekeeping + unknown-URI rejection)
- [x] Full suite: 1548 pass, 20 skipped, 0 fail
- [x] Verified end-to-end via stdio:
  \`\`\`
  resources/list → 4 resources
  resources/read strudel://styles → 15 styles
  resources/read strudel://docs/tools → 70 tools
  \`\`\`

## Out of scope

- Subscriptions (resources/subscribe) — file separate issue if a client wants live updates on the saved-patterns catalog
- Non-JSON mime types
- Mutating resources (writes stay as tools)
- Explicit cache headers — current implementation refetches on every read, adequate at expected list sizes