### PR TITLE
feat: standardize MCP tool result envelope at protocol dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -695,10 +695,40 @@ describe('AudioAnalyzer - Tempo Detection', () => {
 }
 ```
 
-**Return Values:**
-- Success: Return data or descriptive message
-- Failure: Return error object with `error` key
-- Include context: `{ bpm: 174, confidence: 0.92, method: 'onset-based' }`
+**Return Values — the MCP-level envelope (#130):**
+
+Every tool call surfaces to MCP clients wrapped in a discriminated envelope. The dispatcher in `server.ts` does the wrapping; tools can either return raw values (auto-wrapped) or return envelopes natively via the helpers in `src/server/tools/types.ts`:
+
+```typescript
+import { ok, err, empty } from './types.js';
+
+// success with data
+return ok({ bpm: 174, confidence: 0.92, method: 'onset-based' });
+
+// valid-empty result (call worked but nothing to return)
+return empty([]);
+
+// business-state failure (setup needed, don't retry)
+return err('business', 'Browser not initialized. Run init first.');
+
+// validation failure (caller passed bad input)
+return err('validation', `Invalid BPM: ${bpm}. Must be 20-300.`);
+
+// transient failure (retryable)
+return err('transient', 'Strudel.cc request timed out', { isRetryable: true });
+```
+
+Wire-level shape MCP clients see:
+
+```json
+{ "ok": true,  "data": { ... } }
+{ "ok": true,  "data": [],     "empty": true }
+{ "ok": false, "errorCategory": "validation", "isRetryable": false, "message": "..." }
+```
+
+`errorCategory` is one of `validation` / `transient` / `business` / `permission` / `internal`. Tools that throw raw `Error`s get categorised by message via `categorizeError()` — fine for the common cases (`Invalid X`, `not found`, `not initialized`, `timeout`, ...), but tools that own a specific error condition should call `err(category, message)` directly so the categorisation isn't string-sniffed.
+
+Module-level adoption is incremental: dispatch normalises legacy `'Browser not initialized...'` and `'Error: ...'` string returns into envelopes, so a tool can keep its current return shape until someone migrates it.
 
 ### 8. Dependency Management
 

--- a/src/__tests__/unit/EnvelopeDispatch.test.ts
+++ b/src/__tests__/unit/EnvelopeDispatch.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the MCP protocol-level result envelope (#130).
+ *
+ * These exercise `StrudelMCPServer.dispatchToolCall` — the wrapper that
+ * turns raw tool returns and thrown errors into the shared envelope
+ * shape every MCP client now sees. Unit-test scope; integration tests
+ * cover the full request/response wire.
+ */
+
+// StrudelMCPServer transitively imports @strudel/* (ESM). Jest's CJS loader
+// can't load that; use the mock that already exists for unit tests.
+jest.mock('../../services/StrudelEngine');
+
+import { StrudelMCPServer } from '../../server/server';
+import {
+  categorizeError,
+  empty,
+  err,
+  isEnvelope,
+  ok,
+} from '../../server/tools/types';
+
+describe('envelope helpers', () => {
+  describe('ok', () => {
+    it('returns the success shape', () => {
+      const e = ok('hi');
+      expect(e).toEqual({ ok: true, data: 'hi' });
+      expect(isEnvelope(e)).toBe(true);
+    });
+  });
+
+  describe('empty', () => {
+    it('marks the result as valid-empty', () => {
+      const e = empty([]);
+      expect(e).toEqual({ ok: true, data: [], empty: true });
+    });
+  });
+
+  describe('err', () => {
+    it('defaults isRetryable false for non-transient categories', () => {
+      const e = err('validation', 'bad input');
+      expect(e).toEqual({
+        ok: false,
+        errorCategory: 'validation',
+        isRetryable: false,
+        message: 'bad input',
+      });
+    });
+
+    it('defaults isRetryable true for transient', () => {
+      const e = err('transient', 'timeout');
+      expect(e.isRetryable).toBe(true);
+    });
+
+    it('honours explicit isRetryable override', () => {
+      expect(err('validation', 'x', { isRetryable: true }).isRetryable).toBe(true);
+      expect(err('transient', 'x', { isRetryable: false }).isRetryable).toBe(false);
+    });
+
+    it('includes partialResult when provided', () => {
+      const e = err('internal', 'half-done', { partialResult: { progress: 0.5 } });
+      expect(e).toMatchObject({
+        ok: false,
+        partialResult: { progress: 0.5 },
+      });
+    });
+  });
+
+  describe('isEnvelope', () => {
+    it('recognises ok envelopes', () => {
+      expect(isEnvelope({ ok: true, data: 'x' })).toBe(true);
+    });
+    it('recognises err envelopes', () => {
+      expect(isEnvelope({ ok: false, errorCategory: 'business', isRetryable: false, message: 'x' })).toBe(true);
+    });
+    it('rejects raw strings and arbitrary objects', () => {
+      expect(isEnvelope('hello')).toBe(false);
+      expect(isEnvelope({ ok: 'truthy-but-not-bool' })).toBe(false);
+      expect(isEnvelope({ data: 'no ok field' })).toBe(false);
+      expect(isEnvelope(null)).toBe(false);
+      expect(isEnvelope(undefined)).toBe(false);
+    });
+  });
+
+  describe('categorizeError', () => {
+    it('maps init phrases to business', () => {
+      expect(categorizeError(new Error('Browser not initialized. Run init first.'))).toBe('business');
+      expect(categorizeError(new Error("Pattern 'foo' not found"))).toBe('business');
+      expect(categorizeError(new Error("Session 'bar' already exists"))).toBe('business');
+    });
+
+    it('maps input phrases to validation', () => {
+      expect(categorizeError(new Error('Invalid BPM: 5000'))).toBe('validation');
+      expect(categorizeError(new Error('BPM must be 20-300'))).toBe('validation');
+      expect(categorizeError(new Error('Style is required'))).toBe('validation');
+      expect(categorizeError(new Error('out of range'))).toBe('validation');
+    });
+
+    it('maps auth/api phrases to permission', () => {
+      expect(categorizeError(new Error('Gemini API key not set'))).toBe('permission');
+      expect(categorizeError(new Error('Unauthorized'))).toBe('permission');
+    });
+
+    it('maps network phrases to transient', () => {
+      expect(categorizeError(new Error('Request timeout after 5s'))).toBe('transient');
+      expect(categorizeError(new Error('ECONNREFUSED'))).toBe('transient');
+      expect(categorizeError(new Error('fetch failed'))).toBe('transient');
+    });
+
+    it('falls back to internal', () => {
+      expect(categorizeError(new Error('something we have never seen'))).toBe('internal');
+      expect(categorizeError('non-error thrown')).toBe('internal');
+    });
+  });
+});
+
+describe('StrudelMCPServer.dispatchToolCall', () => {
+  let server: any;
+
+  beforeEach(() => {
+    server = new StrudelMCPServer();
+  });
+
+  it('wraps a raw string return into ok(...)', async () => {
+    server.executeTool = jest.fn().mockResolvedValue('Loaded pattern "x"');
+    const e = await server.dispatchToolCall('load', { name: 'x' });
+    expect(e).toEqual({ ok: true, data: 'Loaded pattern "x"' });
+  });
+
+  it('wraps a raw object return into ok(...)', async () => {
+    server.executeTool = jest.fn().mockResolvedValue({ bpm: 174, confidence: 0.92 });
+    const e = await server.dispatchToolCall('detect_tempo', {});
+    expect(e).toEqual({ ok: true, data: { bpm: 174, confidence: 0.92 } });
+  });
+
+  it('converts legacy "Browser not initialized..." string into err(business)', async () => {
+    server.executeTool = jest
+      .fn()
+      .mockResolvedValue('Browser not initialized. Run init first.');
+    const e = await server.dispatchToolCall('play', {});
+    expect(e).toEqual({
+      ok: false,
+      errorCategory: 'business',
+      isRetryable: false,
+      message: 'Browser not initialized. Run init first.',
+    });
+  });
+
+  it('converts legacy "Error: ..." string into err(internal)', async () => {
+    server.executeTool = jest.fn().mockResolvedValue('Error: something blew up');
+    const e = await server.dispatchToolCall('write', { pattern: 'x' });
+    expect(e).toMatchObject({
+      ok: false,
+      errorCategory: 'internal',
+      message: 'something blew up',
+    });
+  });
+
+  it('passes pre-built envelopes through unchanged', async () => {
+    const passthrough = err('permission', 'GEMINI_API_KEY missing');
+    server.executeTool = jest.fn().mockResolvedValue(passthrough);
+    const e = await server.dispatchToolCall('get_pattern_feedback', {});
+    expect(e).toBe(passthrough);
+  });
+
+  it('passes pre-built ok(...) envelopes through unchanged', async () => {
+    const passthrough = ok({ x: 1 });
+    server.executeTool = jest.fn().mockResolvedValue(passthrough);
+    const e = await server.dispatchToolCall('analyze', {});
+    expect(e).toBe(passthrough);
+  });
+
+  it('catches thrown Error and categorises by message', async () => {
+    server.executeTool = jest.fn().mockRejectedValue(new Error('Invalid BPM: 5000'));
+    const e = await server.dispatchToolCall('set_tempo', { bpm: 5000 });
+    expect(e).toEqual({
+      ok: false,
+      errorCategory: 'validation',
+      isRetryable: false,
+      message: 'Invalid BPM: 5000',
+    });
+  });
+
+  it('catches non-Error throws and reports them as internal', async () => {
+    server.executeTool = jest.fn().mockRejectedValue('plain string thrown');
+    const e = await server.dispatchToolCall('whatever', {});
+    expect(e.ok).toBe(false);
+    if (!e.ok) {
+      expect(e.errorCategory).toBe('internal');
+      expect(e.message).toBe('plain string thrown');
+    }
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -31,7 +31,8 @@ import { sessionModule } from './tools/session.js';
 import { captureModule } from './tools/capture.js';
 import { aiModule } from './tools/ai.js';
 import { composeModule } from './tools/compose.js';
-import type { ToolContext, HistoryEntry } from './tools/types.js';
+import type { Envelope, ToolContext, HistoryEntry } from './tools/types.js';
+import { categorizeError, err, isEnvelope, ok } from './tools/types.js';
 import { readResource, resources as mcpResources } from './resources.js';
 import { join } from 'node:path';
 
@@ -120,32 +121,10 @@ export class StrudelMCPServer {
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-
-      try {
-        this.logger.info(`Executing tool: ${name}`, args);
-
-        // Measure performance
-        const result = await this.perfMonitor.measureAsync(
-          name,
-          () => this.executeTool(name, args)
-        );
-
-        return {
-          content: [{
-            type: 'text',
-            text: typeof result === 'string' ? result : JSON.stringify(result, null, 2)
-          }],
-        };
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.error(`Tool execution failed: ${name}`, { error: message });
-        return {
-          content: [{
-            type: 'text',
-            text: `Error: ${message}`
-          }],
-        };
-      }
+      const envelope = await this.dispatchToolCall(name, args);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
+      };
     });
 
     // MCP resources — read-only catalogs (#131). Resource handlers stay
@@ -168,6 +147,54 @@ export class StrudelMCPServer {
         throw error;
       }
     });
+  }
+
+  /**
+   * Wraps every tool call into the shared envelope (#130).
+   *
+   * Tools may return:
+   *   - a raw value → auto-wrapped via `ok(value)`
+   *   - a pre-built Envelope (via the `ok()`/`err()`/`empty()` helpers in
+   *     `tools/types.ts`) → passed through unchanged
+   *   - an "error-shaped" string (starts with "Error: " or "Browser not
+   *     initialized") → converted to `err(...)` so legacy modules still
+   *     surface as failures while their internal migration to envelope
+   *     helpers proceeds incrementally
+   *
+   * Thrown errors are caught and converted to `err(...)` with a category
+   * inferred from the message (see `categorizeError`).
+   */
+  private async dispatchToolCall(name: string, args: unknown): Promise<Envelope> {
+    try {
+      this.logger.info(`Executing tool: ${name}`, args);
+      const result = await this.perfMonitor.measureAsync(
+        name,
+        () => this.executeTool(name, args),
+      );
+
+      if (isEnvelope(result)) {
+        return result;
+      }
+
+      // Convert legacy "Error: ..." / "Browser not initialized" string returns
+      // into the envelope. Module-level migration is incremental — this branch
+      // shrinks as modules adopt the helpers natively.
+      if (typeof result === 'string') {
+        if (result.startsWith('Error: ')) {
+          return err('internal', result.slice('Error: '.length));
+        }
+        if (result.startsWith('Browser not initialized')) {
+          return err('business', result);
+        }
+        return ok(result);
+      }
+
+      return ok(result);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Tool execution failed: ${name}`, { error: message });
+      return err(categorizeError(error), message);
+    }
   }
 
   private requiresInitialization(toolName: string): boolean {

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -86,3 +86,133 @@ export interface ToolModule {
   /** Execute a tool by name. Throws if the name is unknown to this module. */
   execute(name: string, args: any, ctx: ToolContext): Promise<unknown>;
 }
+
+/**
+ * Tool result envelope (#130, from #127 finding #4-5).
+ *
+ * Every tool call resolves to one of these. server.ts dispatch wraps
+ * raw returns and thrown errors into the envelope so MCP clients see a
+ * consistent shape and can branch on `ok` + `errorCategory` without
+ * parsing free-text messages.
+ *
+ * Tools may also return an Envelope directly (constructed via `ok()` /
+ * `err()` / `empty()`); the dispatch passes those through unchanged.
+ *
+ * Categories:
+ *   - `validation`  — caller-supplied input is wrong (don't retry, fix args)
+ *   - `transient`   — network / external service hiccup (retry with backoff)
+ *   - `business`    — system state prevents the action (e.g. browser not
+ *                     initialized; setup needed, not retry)
+ *   - `permission`  — auth / config missing (e.g. Gemini key absent)
+ *   - `internal`    — unexpected failure inside the server; bug shape
+ */
+export type ErrorCategory =
+  | 'validation'
+  | 'transient'
+  | 'business'
+  | 'permission'
+  | 'internal';
+
+export interface OkEnvelope<T = unknown> {
+  ok: true;
+  data: T;
+  /** True when the call succeeded but produced no records (e.g. empty list). */
+  empty?: boolean;
+}
+
+export interface ErrEnvelope {
+  ok: false;
+  errorCategory: ErrorCategory;
+  isRetryable: boolean;
+  message: string;
+  /** Partial result if the operation produced something usable before failing. */
+  partialResult?: unknown;
+}
+
+export type Envelope<T = unknown> = OkEnvelope<T> | ErrEnvelope;
+
+/** Type guard for tools and dispatchers. */
+export function isEnvelope(v: unknown): v is Envelope {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'ok' in v &&
+    typeof (v as { ok: unknown }).ok === 'boolean'
+  );
+}
+
+/** Construct a success envelope. */
+export function ok<T>(data: T): OkEnvelope<T> {
+  return { ok: true, data };
+}
+
+/**
+ * Construct a success envelope that represents a valid-empty result —
+ * the call worked but produced nothing (no patterns found, empty
+ * history, etc.). Distinct from `err` so agents can choose between
+ * "report nothing" and "retry/setup".
+ */
+export function empty<T>(data: T): OkEnvelope<T> {
+  return { ok: true, data, empty: true };
+}
+
+/** Construct an error envelope. */
+export function err(
+  category: ErrorCategory,
+  message: string,
+  opts?: { isRetryable?: boolean; partialResult?: unknown },
+): ErrEnvelope {
+  return {
+    ok: false,
+    errorCategory: category,
+    // Default retryability follows category: transient retries, others don't.
+    isRetryable: opts?.isRetryable ?? category === 'transient',
+    message,
+    ...(opts?.partialResult !== undefined ? { partialResult: opts.partialResult } : {}),
+  };
+}
+
+/**
+ * Best-effort error categorization for raw thrown errors. Used by the
+ * dispatcher when a tool throws without wrapping. Tools that know better
+ * should construct `err(category, message)` directly.
+ */
+export function categorizeError(error: unknown): ErrorCategory {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes('not initialized') ||
+    lower.includes("run 'init' first") ||
+    lower.includes('run init first') ||
+    lower.includes('not found') ||
+    lower.includes('already exists')
+  ) {
+    return 'business';
+  }
+  if (
+    lower.includes('invalid') ||
+    lower.includes('must be') ||
+    lower.includes('required') ||
+    lower.includes('out of range')
+  ) {
+    return 'validation';
+  }
+  if (
+    lower.includes('gemini') ||
+    lower.includes('api key') ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden')
+  ) {
+    return 'permission';
+  }
+  if (
+    lower.includes('timeout') ||
+    lower.includes('econnrefused') ||
+    lower.includes('network') ||
+    lower.includes('fetch failed')
+  ) {
+    return 'transient';
+  }
+  return 'internal';
+}


### PR DESCRIPTION
Closes #130. Closes #127.

Every tool call now surfaces to MCP clients wrapped in a discriminated envelope. Agents can branch on \`{ ok, errorCategory, isRetryable }\` instead of parsing free-text messages.

## What lands

1. **Envelope helpers** in \`src/server/tools/types.ts\` — \`ok()\`, \`empty()\`, \`err(category, message, opts?)\`, \`isEnvelope()\`, \`categorizeError()\`. Five categories: \`validation\` / \`transient\` / \`business\` / \`permission\` / \`internal\`. Default \`isRetryable\` follows category (transient retries, others don't) with explicit override.

2. **Dispatcher wraps everything** — \`server.ts\` splits the \`CallToolRequestSchema\` handler into a thin shell + \`dispatchToolCall\`. The dispatcher:
   - passes pre-built envelopes through (tools can opt-in natively)
   - auto-wraps raw values into \`ok(value)\`
   - normalises legacy \`Browser not initialized...\` / \`Error: ...\` string returns into \`err(business|internal, ...)\`
   - catches thrown Errors and categorises by message regex

3. **Tests** — 22 new cases in \`src/__tests__/unit/EnvelopeDispatch.test.ts\` cover helper correctness, dispatcher wrapping for raw strings / raw objects / pre-built envelopes / thrown Errors / non-Error throws, and \`categorizeError\` pattern matching.

4. **CLAUDE.md** — documents the envelope contract under "Return Values" so the next person adding a tool knows the shape.

## Wire shape

\`\`\`json
{ "ok": true,  "data": { ... } }
{ "ok": true,  "data": [],     "empty": true }
{ "ok": false, "errorCategory": "validation", "isRetryable": false, "message": "..." }
\`\`\`

## Scope decision

Module-level adoption is **incremental**: every existing module keeps its current return shape and the dispatcher normalises. As tools get touched for other reasons they can adopt the helpers natively. The protocol-level surface — which is what #130 was really about — is consistent today, without invalidating ~150 module-level test assertions that lock current return shapes.

## Test plan

- [x] 22 new envelope tests pass
- [x] Full suite: 1571 pass, 20 skipped, 0 fail (was 1549 → +22)
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean (0 errors, 126 warnings)
- [x] Verified end-to-end via stdio — \`tools/call\` returns envelope JSON, both success and categorised-error paths render correctly

## Closes #127

Every finding in @nareto's audit now has an owner:

| Finding | Owner |
|---|---|
| #1 flat 66-tool surface | #120 (consolidation epic) |
| #2 under-specified descriptions | #120 AC extended |
| #3 scattered tool metadata | addressed by #104 module split |
| #4 + #5 error contract / empty-vs-failure | **this PR** |
| #6 MCP resources | #131 (shipped) |