### PR TITLE
feat(#108): thread session_id through every browser-touching tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `compose` | Generate, write, and play a complete pattern in one step. Auto-initializes browser if needed. |
+| `compose` | Generate, write, and play a complete pattern in one step. Auto-initializes default browser if needed. |
 | `generate_pattern` | Generate complete pattern from style with optional auto-play |
 | `generate_drums` | Generate drum pattern |
 | `generate_bassline` | Generate bassline |

--- a/src/__tests__/integration/MCPServer.integration.test.ts
+++ b/src/__tests__/integration/MCPServer.integration.test.ts
@@ -165,23 +165,20 @@ describe('MCP Server Integration Tests', () => {
   });
 
   describe('Tool Execution Logic', () => {
-    test('should require initialization for write tool', async () => {
+    test('write tool refuses without init', async () => {
       const serverAny = server as any;
-
-      const requiresInit = serverAny.requiresInitialization('write');
-      expect(requiresInit).toBe(true);
+      // requiresInitialization() was removed (#141/#108). Each module's
+      // execute() now does its own session-aware init check.
+      const result = await serverAny.executeTool('write', { pattern: 's("bd")' });
+      expect(typeof result === 'string' && result.includes('not initialized')).toBe(true);
     });
 
-    test('should not require initialization for music theory tools', async () => {
+    test('music theory tools run without browser', async () => {
       const serverAny = server as any;
-
-      // generate_scale is pure music theory - doesn't require init
-      expect(serverAny.requiresInitialization('generate_scale')).toBe(false);
-
-      // These tools require init for browser writing, but can work without it
-      // requiresInitialization returns true, but executeTool has special handling for them
-      expect(serverAny.requiresInitialization('generate_chord_progression')).toBe(true);
-      expect(serverAny.requiresInitialization('generate_euclidean')).toBe(true);
+      // generate_scale is pure music theory and returns scale notes directly.
+      const result = await serverAny.executeTool('generate_scale', { root: 'C', scale: 'major' });
+      expect(typeof result).toBe('string');
+      expect(result).toContain('C, D, E, F, G, A, B');
     });
 
     test('should execute music theory tools without browser', async () => {
@@ -267,7 +264,8 @@ describe('MCP Server Integration Tests', () => {
 
       // When browser is not initialized, write returns initialization message before validation
       const result1 = await serverAny.executeTool('write', {});
-      expect(result1).toBe("Browser not initialized. Run 'init' first to use write.");
+      // Post-#108: each module's execute() returns its own init-refusal message.
+      expect(result1).toContain('not initialized');
 
       // Initialize browser to test actual input validation
       serverAny.isInitialized = true;

--- a/src/__tests__/unit/MultiSession.test.ts
+++ b/src/__tests__/unit/MultiSession.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Two-session isolation test (#108).
+ *
+ * Exercises the session_id routing across the tool modules: each named
+ * session sees its own pattern state, no cross-talk, and asking for a
+ * non-existent session surfaces err('business').
+ *
+ * Stubs StrudelController so the test runs without a real browser.
+ * Stubs StrudelEngine because @strudel/* is ESM-only and Jest can't load
+ * it directly (the same reason #107 needed pure helpers).
+ */
+
+jest.mock('../../services/StrudelEngine');
+
+import type { StrudelController } from '../../StrudelController';
+import {
+  execute as editorExecute,
+  toolNames as editorToolNames,
+} from '../../server/tools/editor';
+import {
+  execute as playbackExecute,
+} from '../../server/tools/playback';
+import type { ToolContext } from '../../server/tools/types';
+import { err } from '../../server/tools/types';
+
+/**
+ * Minimal controller stub: in-memory pattern + play/stop flag. Each
+ * session gets its own stub so isolation is observable.
+ */
+function makeStubController(): jest.Mocked<StrudelController> {
+  let pattern = '';
+  let playing = false;
+  return {
+    writePattern: jest.fn(async (p: string) => { pattern = p; return 'written'; }),
+    getCurrentPattern: jest.fn(async () => pattern),
+    play: jest.fn(async () => { playing = true; }),
+    stop: jest.fn(async () => { playing = false; }),
+    showBrowser: jest.fn(async () => 'shown'),
+    getStatus: jest.fn(() => ({ playing, patternLength: pattern.length })),
+    validatePattern: jest.fn(async () => ({ valid: true, errors: [], warnings: [], suggestions: [] })),
+  } as any;
+}
+
+function makeCtx(sessions: Record<string, StrudelController>, legacyController: StrudelController): ToolContext {
+  return {
+    controller: legacyController,
+    perfMonitor: { measureAsync: async (_n: string, fn: any) => fn() } as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => true,
+    ensureInitialized: async () => {},
+    getController(sessionId?: string): StrudelController {
+      if (!sessionId) return legacyController;
+      const c = sessions[sessionId];
+      if (!c) {
+        throw new Error(`Session '${sessionId}' not found. Create it first with create_session.`);
+      }
+      return c;
+    },
+    getCurrentPatternSafe: async (sessionId?: string) => {
+      const c = sessionId ? sessions[sessionId] : legacyController;
+      if (!c) throw new Error(`Session '${sessionId}' not found. Create it first with create_session.`);
+      return await c.getCurrentPattern();
+    },
+    writePatternSafe: async (pattern: string, sessionId?: string) => {
+      const c = sessionId ? sessions[sessionId] : legacyController;
+      if (!c) throw new Error(`Session '${sessionId}' not found. Create it first with create_session.`);
+      return await c.writePattern(pattern);
+    },
+  };
+}
+
+describe('two-session isolation (#108)', () => {
+  let sessionA: jest.Mocked<StrudelController>;
+  let sessionB: jest.Mocked<StrudelController>;
+  let legacy: jest.Mocked<StrudelController>;
+  let ctx: ToolContext;
+
+  beforeEach(() => {
+    sessionA = makeStubController();
+    sessionB = makeStubController();
+    legacy = makeStubController();
+    ctx = makeCtx({ A: sessionA, B: sessionB }, legacy);
+  });
+
+  it('write with session_id targets the named session, not the legacy controller', async () => {
+    await editorExecute('write', { pattern: 's("bd")', session_id: 'A' }, ctx);
+
+    expect(sessionA.writePattern).toHaveBeenCalledWith('s("bd")');
+    expect(sessionB.writePattern).not.toHaveBeenCalled();
+    expect(legacy.writePattern).not.toHaveBeenCalled();
+  });
+
+  it('two sessions see independent patterns', async () => {
+    await editorExecute('write', { pattern: 's("bd")', session_id: 'A' }, ctx);
+    await editorExecute('write', { pattern: 'note("c3")', session_id: 'B' }, ctx);
+
+    const aPattern = await editorExecute('get_pattern', { session_id: 'A' }, ctx);
+    const bPattern = await editorExecute('get_pattern', { session_id: 'B' }, ctx);
+
+    expect(aPattern).toBe('s("bd")');
+    expect(bPattern).toBe('note("c3")');
+  });
+
+  it('omitting session_id routes to the legacy controller', async () => {
+    await editorExecute('write', { pattern: 's("hh")' }, ctx);
+
+    expect(legacy.writePattern).toHaveBeenCalledWith('s("hh")');
+    expect(sessionA.writePattern).not.toHaveBeenCalled();
+    expect(sessionB.writePattern).not.toHaveBeenCalled();
+  });
+
+  it('explicit non-existent session throws (dispatcher renders as err business)', async () => {
+    await expect(
+      editorExecute('write', { pattern: 'x', session_id: 'does-not-exist' }, ctx),
+    ).rejects.toThrow(/Session 'does-not-exist' not found/);
+  });
+
+  it('playback routes per session', async () => {
+    await playbackExecute('play', { session_id: 'A' }, ctx);
+    expect(sessionA.play).toHaveBeenCalledTimes(1);
+    expect(sessionB.play).not.toHaveBeenCalled();
+    expect(legacy.play).not.toHaveBeenCalled();
+
+    await playbackExecute('stop', { session_id: 'B' }, ctx);
+    expect(sessionB.stop).toHaveBeenCalledTimes(1);
+    expect(sessionA.stop).not.toHaveBeenCalled();
+  });
+
+  it('append/insert/replace/clear all route by session_id', async () => {
+    await editorExecute('write', { pattern: 's("bd")', session_id: 'A' }, ctx);
+    await editorExecute('append', { code: '.fast(2)', session_id: 'A' }, ctx);
+    expect(sessionA.writePattern).toHaveBeenLastCalledWith('s("bd")\n.fast(2)');
+
+    await editorExecute('replace', { search: 'bd', replace: 'sd', session_id: 'A' }, ctx);
+    expect(sessionA.writePattern).toHaveBeenLastCalledWith('s("sd")\n.fast(2)');
+
+    await editorExecute('clear', { session_id: 'B' }, ctx);
+    expect(sessionB.writePattern).toHaveBeenCalledWith('');
+    // Session A's clear was not called.
+    const aCalls = sessionA.writePattern.mock.calls;
+    expect(aCalls.some(c => c[0] === '')).toBe(false);
+  });
+
+  it('every editor tool schema accepts session_id', () => {
+    // Sanity check the inputSchema additions — every tool in the editor
+    // module should now expose `session_id` as a property.
+    // (toolNames is just an order-preserving Set; we look up via tools.)
+    const { tools } = require('../../server/tools/editor');
+    for (const t of tools) {
+      expect(editorToolNames.has(t.name)).toBe(true);
+      expect((t.inputSchema as any).properties.session_id).toBeDefined();
+    }
+  });
+});
+
+describe('envelope wrapping for session errors', () => {
+  it('err(business) is the right shape for missing sessions', () => {
+    const e = err('business', "Session 'nope' not found. Create it first with create_session.");
+    expect(e).toEqual({
+      ok: false,
+      errorCategory: 'business',
+      isRetryable: false,
+      message: "Session 'nope' not found. Create it first with create_session.",
+    });
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -197,41 +197,50 @@ export class StrudelMCPServer {
     }
   }
 
-  private requiresInitialization(toolName: string): boolean {
-    const toolsRequiringInit = [
-      'write', 'append', 'insert', 'replace', 'play', 'pause', 'stop',
-      'clear', 'get_pattern', 'analyze', 'analyze_spectrum', 'analyze_rhythm',
-      'transpose', 'reverse', 'stretch', 'humanize', 'generate_variation',
-      'add_effect', 'add_swing', 'set_tempo', 'save', 'undo', 'redo',
-      'validate_pattern_runtime'
-    ];
-    
-    const toolsRequiringWrite = [
-      'generate_pattern', 'generate_drums', 'generate_bassline', 'generate_melody',
-      'generate_chord_progression', 'generate_euclidean', 'generate_polyrhythm',
-      'generate_fill'
-    ];
-    
-    return toolsRequiringInit.includes(toolName) || toolsRequiringWrite.includes(toolName);
-  }
+  // requiresInitialization() removed (#141 / #108): each module's
+  // execute() does its own session-aware init check. The hardcoded
+  // tool-name lists had drifted and were silently wrong for explicit
+  // session_id.
 
-  private async getCurrentPatternSafe(): Promise<string> {
+  private async getCurrentPatternSafe(sessionId?: string): Promise<string> {
+    if (sessionId) {
+      // Explicit session — strict lookup, no pre-init stash. Named sessions
+      // must be created via `create_session` before they're useful.
+      const sessionController = this.sessionManager.getSession(sessionId);
+      if (!sessionController) {
+        throw new Error(`Session '${sessionId}' not found. Create it first with create_session.`);
+      }
+      try {
+        return await sessionController.getCurrentPattern();
+      } catch {
+        return '';
+      }
+    }
+
     if (!this.isInitialized) {
-      // Return the last generated pattern if available
+      // Default session: return the last pre-init generated pattern if any
       const lastPattern = Array.from(this.generatedPatterns.values()).pop();
       return lastPattern || '';
     }
-    
+
     try {
       return await this.controller.getCurrentPattern();
-    } catch (e) {
+    } catch {
       return '';
     }
   }
 
-  private async writePatternSafe(pattern: string): Promise<string> {
+  private async writePatternSafe(pattern: string, sessionId?: string): Promise<string> {
+    if (sessionId) {
+      const sessionController = this.sessionManager.getSession(sessionId);
+      if (!sessionController) {
+        throw new Error(`Session '${sessionId}' not found. Create it first with create_session.`);
+      }
+      return await sessionController.writePattern(pattern);
+    }
+
     if (!this.isInitialized) {
-      // Store the pattern for later use
+      // Default session: stash the pattern for the next init/auto-init
       const id = `pattern_${Date.now()}`;
       this.generatedPatterns.set(id, pattern);
       return `Pattern generated (initialize Strudel to use it): ${pattern.substring(0, 50)}...`;
@@ -281,26 +290,21 @@ export class StrudelMCPServer {
   }
 
   private async executeTool(name: string, args: any): Promise<any> {
-    // Check if tool needs initialization
-    if (this.requiresInitialization(name) && !this.isInitialized && name !== 'init') {
-      // For generation tools that don't require browser, handle them specially
-      const generationTools = [
-        'generate_pattern', 'generate_drums', 'generate_bassline', 'generate_melody',
-        'generate_chord_progression', 'generate_euclidean', 'generate_polyrhythm', 'generate_fill'
-      ];
-      
-      if (!generationTools.includes(name)) {
-        return `Browser not initialized. Run 'init' first to use ${name}.`;
-      }
-    }
+    // Pre-flight init check removed (#141): every module's execute() does
+    // its own session-aware init check via ctx.isInitialized() /
+    // ctx.getController(sid). The old hardcoded tool-name list drifted as
+    // tools moved between modules and #108 made it silently wrong for
+    // explicit session_id (it returned "Browser not initialized" instead
+    // of "Session 'X' not found").
 
-    // Save current state for undo and history (#41) (only if initialized)
-    if (['write', 'append', 'insert', 'replace', 'clear'].includes(name) && this.isInitialized) {
+    // Save current state for undo and history (#41) before any edit on the
+    // default session. Named-session edits bypass the legacy undo stack —
+    // per-session history is tracked in #140 follow-up.
+    if (['write', 'append', 'insert', 'replace', 'clear'].includes(name) && this.isInitialized && !args?.session_id) {
       try {
         const current = await this.controller.getCurrentPattern();
         this.undoStack.push(current);
 
-        // Add to history stack with metadata (#41)
         this.historyIdCounter++;
         this.historyStack.push({
           id: this.historyIdCounter,
@@ -309,7 +313,6 @@ export class StrudelMCPServer {
           action: name
         });
 
-        // Enforce bounds to prevent memory leaks
         if (this.undoStack.length > this.MAX_HISTORY) {
           this.undoStack.shift();
         }
@@ -317,7 +320,7 @@ export class StrudelMCPServer {
           this.historyStack.shift();
         }
         this.redoStack = [];
-      } catch (e) {
+      } catch {
         // Controller might not be initialized yet
       }
     }
@@ -345,8 +348,9 @@ export class StrudelMCPServer {
       logger: this.logger,
       isInitialized: () => this.isInitialized,
       ensureInitialized: () => this.ensureInitialized(),
-      getCurrentPatternSafe: () => this.getCurrentPatternSafe(),
-      writePatternSafe: (p: string) => this.writePatternSafe(p),
+      getController: (sessionId?: string) => this.getControllerForSession(sessionId),
+      getCurrentPatternSafe: (sessionId?: string) => this.getCurrentPatternSafe(sessionId),
+      writePatternSafe: (p: string, sessionId?: string) => this.writePatternSafe(p, sessionId),
     };
     if (diagnosticsModule.toolNames.has(name)) {
       return await diagnosticsModule.execute(name, args, ctx);

--- a/src/server/tools/ai.ts
+++ b/src/server/tools/ai.ts
@@ -20,6 +20,13 @@ import { Logger } from '../../utils/Logger.js';
 
 const logger = new Logger();
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'get_pattern_feedback',
@@ -29,6 +36,7 @@ export const tools: Tool[] = [
       properties: {
         includeAudio: { type: 'boolean', description: 'Include audio analysis (plays pattern briefly). Default: false' },
         style: { type: 'string', description: 'Optional style hint for context (e.g., "techno", "ambient")' },
+        ...SESSION_ID_PROP,
       },
     },
   },
@@ -44,6 +52,7 @@ export const tools: Tool[] = [
           enum: ['complement', 'bassline', 'melody', 'percussion'],
           description: 'What role the suggested pattern should fill. Default: complement',
         },
+        ...SESSION_ID_PROP,
       },
     },
   },
@@ -60,6 +69,7 @@ export const tools: Tool[] = [
         },
         style_hint: { type: 'string', description: 'Optional style guidance (e.g., "funky", "minimal", "atmospheric")' },
         auto_play: { type: 'boolean', description: 'Start playback after adding layer (default: true)' },
+        ...SESSION_ID_PROP,
       },
       required: ['layer'],
     },
@@ -69,15 +79,16 @@ export const tools: Tool[] = [
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
   switch (name) {
     case 'get_pattern_feedback':
-      return await getPatternFeedback(args?.includeAudio || false, args?.style, ctx);
+      return await getPatternFeedback(args?.includeAudio || false, args?.style, ctx, sid);
 
     case 'suggest_pattern_from_audio':
-      return await suggestPatternFromAudio(args?.style, args?.role || 'complement', ctx);
+      return await suggestPatternFromAudio(args?.style, args?.role || 'complement', ctx, sid);
 
     case 'jam_with':
-      return await jamWith(args.layer, args.style_hint, args.auto_play, ctx);
+      return await jamWith(args.layer, args.style_hint, args.auto_play, ctx, sid);
 
     default:
       throw new Error(`ai module does not handle tool: ${name}`);
@@ -92,6 +103,7 @@ async function getPatternFeedback(
   includeAudio: boolean,
   style: string | undefined,
   ctx: ToolContext,
+  sid?: string,
 ): Promise<{
   pattern_analysis?: CreativeFeedback;
   audio_analysis?: AudioFeedback;
@@ -105,7 +117,7 @@ async function getPatternFeedback(
     };
   }
 
-  const pattern = await ctx.getCurrentPatternSafe();
+  const pattern = await ctx.getCurrentPatternSafe(sid);
   if (!pattern || pattern.trim().length === 0) {
     return { gemini_available: true, error: 'No pattern to analyze. Write a pattern first.' };
   }
@@ -128,9 +140,9 @@ async function getPatternFeedback(
     result.error = `Pattern analysis failed: ${message}`;
   }
 
-  if (includeAudio && ctx.isInitialized()) {
+  if (includeAudio && (sid || ctx.isInitialized())) {
     try {
-      const audioBlob = await captureAudioSampleForFeedback(ctx);
+      const audioBlob = await captureAudioSampleForFeedback(ctx, sid);
       if (audioBlob) {
         result.audio_analysis = await ctx.geminiService.analyzeAudio(audioBlob, { style, duration: 5 });
       } else {
@@ -156,8 +168,8 @@ async function getPatternFeedback(
  * analyzer's AudioContext and records 5 seconds without disturbing
  * the full AudioCaptureService lifecycle.
  */
-async function captureAudioSampleForFeedback(ctx: ToolContext): Promise<Blob | null> {
-  const page = ctx.controller.page;
+async function captureAudioSampleForFeedback(ctx: ToolContext, sid?: string): Promise<Blob | null> {
+  const page = ctx.getController(sid).page;
   if (!page) {
     logger.warn('Cannot capture audio: controller page not available');
     return null;
@@ -219,22 +231,24 @@ async function suggestPatternFromAudio(
   style: string | undefined,
   role: string,
   ctx: ToolContext,
+  sid?: string,
 ): Promise<Record<string, unknown>> {
-  if (!ctx.isInitialized()) {
+  if (!sid && !ctx.isInitialized()) {
     return { error: 'Browser not initialized. Run init and play a pattern first.' };
   }
   if (!ctx.geminiService.isAvailable()) {
     return { error: 'Gemini API not configured. Set GEMINI_API_KEY to enable AI features.' };
   }
+  const controller = ctx.getController(sid);
 
   let bpm = 0, key = 'C', scale = 'major';
   try {
-    const tempoResult = await ctx.controller.detectTempo();
+    const tempoResult = await controller.detectTempo();
     if (tempoResult && tempoResult.bpm > 0) bpm = tempoResult.bpm;
   } catch { /* best effort */ }
 
   try {
-    const keyResult = await ctx.controller.detectKey();
+    const keyResult = await controller.detectKey();
     if (keyResult && keyResult.confidence > 0.1) {
       key = keyResult.key;
       scale = keyResult.scale;
@@ -296,6 +310,7 @@ async function jamWith(
   styleHint: string | undefined,
   autoPlay: boolean = true,
   ctx: ToolContext,
+  sid?: string,
 ): Promise<{
   success: boolean;
   message: string;
@@ -316,7 +331,7 @@ async function jamWith(
     };
   }
 
-  const currentPattern = await ctx.getCurrentPatternSafe();
+  const currentPattern = await ctx.getCurrentPatternSafe(sid);
   if (!currentPattern || currentPattern.trim().length === 0) {
     return {
       success: false,
@@ -354,9 +369,9 @@ async function jamWith(
   const mergedPattern = mergeLayerIntoPattern(currentPattern, newLayer, layer);
 
   try {
-    await ctx.writePatternSafe(mergedPattern);
-    if (autoPlay && ctx.isInitialized()) {
-      await ctx.controller.play();
+    await ctx.writePatternSafe(mergedPattern, sid);
+    if (autoPlay && (sid || ctx.isInitialized())) {
+      await ctx.getController(sid).play();
     }
     return {
       success: true,

--- a/src/server/tools/analysis.ts
+++ b/src/server/tools/analysis.ts
@@ -21,31 +21,38 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'analyze',
     description: 'Complete audio analysis',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'analyze_spectrum',
     description: 'FFT spectrum analysis',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'analyze_rhythm',
     description: 'Rhythm analysis',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'detect_tempo',
     description: 'BPM detection',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'detect_key',
     description: 'Key detection',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'validate_pattern_runtime',
@@ -55,6 +62,7 @@ export const tools: Tool[] = [
       properties: {
         pattern: { type: 'string', description: 'Pattern code to validate' },
         waitMs: { type: 'number', description: 'How long to wait for errors (default 500ms)' },
+        ...SESSION_ID_PROP,
       },
       required: ['pattern'],
     },
@@ -118,25 +126,27 @@ const LOCAL_ENGINE_TOOLS = new Set([
 ]);
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
-  if (!LOCAL_ENGINE_TOOLS.has(name) && !ctx.isInitialized()) {
+  const sid: string | undefined = args?.session_id;
+  if (!LOCAL_ENGINE_TOOLS.has(name) && !sid && !ctx.isInitialized()) {
     return 'Browser not initialized. Run init first.';
   }
+  const controller = LOCAL_ENGINE_TOOLS.has(name) ? null : ctx.getController(sid);
 
   switch (name) {
     case 'analyze':
-      return await ctx.controller.analyzeAudio();
+      return await controller!.analyzeAudio();
 
     case 'analyze_spectrum': {
-      const spectrum = await ctx.controller.analyzeAudio();
+      const spectrum = await controller!.analyzeAudio();
       return spectrum.features || spectrum;
     }
 
     case 'analyze_rhythm':
-      return await ctx.controller.analyzeRhythm();
+      return await controller!.analyzeRhythm();
 
     case 'detect_tempo': {
       try {
-        const tempoAnalysis = await ctx.controller.detectTempo();
+        const tempoAnalysis = await controller!.detectTempo();
         if (!tempoAnalysis || tempoAnalysis.bpm === 0) {
           return {
             bpm: 0,
@@ -158,7 +168,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
 
     case 'detect_key': {
       try {
-        const keyAnalysis = await ctx.controller.detectKey();
+        const keyAnalysis = await controller!.detectKey();
         if (!keyAnalysis || keyAnalysis.confidence < 0.1) {
           return {
             key: 'Unknown',
@@ -189,7 +199,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
 
     case 'validate_pattern_runtime': {
       InputValidator.validateStringLength(args.pattern, 'pattern', 10000, false);
-      const validation = await ctx.controller.validatePatternRuntime(
+      const validation = await controller!.validatePatternRuntime(
         args.pattern,
         args.waitMs || 500,
       );

--- a/src/server/tools/capture.ts
+++ b/src/server/tools/capture.ts
@@ -30,6 +30,13 @@ function blobToBase64(arrayBuffer: ArrayBuffer): string {
   return btoa(binary);
 }
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Routes page reference to the named session. Note: AudioCaptureService is currently server-wide — concurrent captures across sessions will conflict.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'start_audio_capture',
@@ -39,20 +46,24 @@ export const tools: Tool[] = [
       properties: {
         format: { type: 'string', enum: ['webm', 'opus'], description: 'Audio format (default: webm)' },
         maxDuration: { type: 'number', description: 'Maximum capture duration in milliseconds' },
+        ...SESSION_ID_PROP,
       },
     },
   },
   {
     name: 'stop_audio_capture',
     description: 'Stop audio capture and return the recorded audio as base64-encoded data.',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'capture_audio_sample',
     description: 'Capture a fixed-duration audio sample from Strudel output. Audio must be playing.',
     inputSchema: {
       type: 'object',
-      properties: { duration: { type: 'number', description: 'Duration in milliseconds (default: 5000)' } },
+      properties: {
+        duration: { type: 'number', description: 'Duration in milliseconds (default: 5000)' },
+        ...SESSION_ID_PROP,
+      },
     },
   },
   {
@@ -65,6 +76,7 @@ export const tools: Tool[] = [
         duration: { type: 'number', description: 'Export duration in bars (default: 4)' },
         bpm: { type: 'number', description: 'Tempo in BPM (default: 120)' },
         format: { type: 'string', enum: ['file', 'base64'], description: 'Output format: file or base64 (default: base64)' },
+        ...SESSION_ID_PROP,
       },
     },
   },
@@ -73,18 +85,22 @@ export const tools: Tool[] = [
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
+  // No outer init check: each capture handler has try/catch that
+  // produces a structured { success: false, message } from any error,
+  // including AudioCaptureService's "Browser not initialized" throw.
   switch (name) {
     case 'start_audio_capture':
-      return await startAudioCapture(args?.format, args?.maxDuration, ctx);
+      return await startAudioCapture(args?.format, args?.maxDuration, ctx, sid);
 
     case 'stop_audio_capture':
-      return await stopAudioCapture(ctx);
+      return await stopAudioCapture(ctx, sid);
 
     case 'capture_audio_sample':
-      return await captureAudioSample(args?.duration, ctx);
+      return await captureAudioSample(args?.duration, ctx, sid);
 
     case 'export_midi':
-      return await exportMidi(args?.filename, args?.duration, args?.bpm, args?.format, ctx);
+      return await exportMidi(args?.filename, args?.duration, args?.bpm, args?.format, ctx, sid);
 
     default:
       throw new Error(`capture module does not handle tool: ${name}`);
@@ -95,13 +111,14 @@ async function startAudioCapture(
   format: 'webm' | 'opus' | undefined,
   _maxDuration: number | undefined,
   ctx: ToolContext,
+  sid?: string,
 ): Promise<unknown> {
   try {
     const service = await ctx.getAudioCaptureService();
     if (service.isCapturing()) {
       return { success: false, message: 'Audio capture already in progress. Stop it first.' };
     }
-    await service.startCapture(ctx.controller.page!, { format });
+    await service.startCapture(ctx.getController(sid).page!, { format });
     return {
       success: true,
       message: 'Audio capture started. Use stop_audio_capture to get the recorded audio.',
@@ -113,13 +130,13 @@ async function startAudioCapture(
   }
 }
 
-async function stopAudioCapture(ctx: ToolContext): Promise<unknown> {
+async function stopAudioCapture(ctx: ToolContext, sid?: string): Promise<unknown> {
   try {
     const service = await ctx.getAudioCaptureService();
     if (!service.isCapturing()) {
       return { success: false, message: 'No audio capture in progress. Start capture first.' };
     }
-    const result = await service.stopCapture(ctx.controller.page!);
+    const result = await service.stopCapture(ctx.getController(sid).page!);
     const buf = await result.blob.arrayBuffer();
     return {
       success: true,
@@ -134,7 +151,7 @@ async function stopAudioCapture(ctx: ToolContext): Promise<unknown> {
   }
 }
 
-async function captureAudioSample(duration: number | undefined, ctx: ToolContext): Promise<unknown> {
+async function captureAudioSample(duration: number | undefined, ctx: ToolContext, sid?: string): Promise<unknown> {
   const durationMs = duration || 5000;
   if (durationMs < 100 || durationMs > 60000) {
     return { success: false, message: 'Duration must be between 100ms and 60000ms (1 minute)' };
@@ -145,7 +162,7 @@ async function captureAudioSample(duration: number | undefined, ctx: ToolContext
     if (service.isCapturing()) {
       return { success: false, message: 'Audio capture already in progress. Stop it first.' };
     }
-    const result = await service.captureForDuration(ctx.controller.page!, durationMs);
+    const result = await service.captureForDuration(ctx.getController(sid).page!, durationMs);
     const buf = await result.blob.arrayBuffer();
     return {
       success: true,
@@ -166,13 +183,14 @@ async function exportMidi(
   bpm: number | undefined,
   format: 'file' | 'base64' | undefined,
   ctx: ToolContext,
+  sid?: string,
 ): Promise<unknown> {
   if (bpm !== undefined) InputValidator.validateBPM(bpm);
   if (bars !== undefined && (bars < 1 || bars > 128)) {
     return { success: false, message: 'Bars must be between 1 and 128' };
   }
 
-  const pattern = await ctx.getCurrentPatternSafe();
+  const pattern = await ctx.getCurrentPatternSafe(sid);
   if (!pattern || pattern.trim().length === 0) {
     return { success: false, message: 'No pattern to export. Write a pattern first.' };
   }

--- a/src/server/tools/compose.ts
+++ b/src/server/tools/compose.ts
@@ -16,15 +16,22 @@ import type { CreativeFeedback } from '../../services/GeminiService.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session. compose auto-init only applies to default session — named sessions must already exist.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'show_browser',
     description: 'Bring browser window to foreground for visual feedback',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'compose',
-    description: 'Generate, write, and play a complete pattern in one step. Auto-initializes browser if needed.',
+    description: 'Generate, write, and play a complete pattern in one step. Auto-initializes default browser if needed.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -33,6 +40,7 @@ export const tools: Tool[] = [
         key: { type: 'string', description: 'Musical key (default: C)' },
         auto_play: { type: 'boolean', description: 'Start playback immediately (default: true)' },
         get_feedback: { type: 'boolean', description: 'Get AI feedback on the generated pattern (default: false)' },
+        ...SESSION_ID_PROP,
       },
       required: ['style'],
     },
@@ -65,12 +73,13 @@ function defaultTempo(style: string): number {
 }
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
   switch (name) {
     case 'show_browser': {
-      if (!ctx.isInitialized()) {
+      if (!sid && !ctx.isInitialized()) {
         return 'Browser not initialized. Run init first.';
       }
-      return await ctx.controller.showBrowser();
+      return await ctx.getController(sid).showBrowser();
     }
 
     case 'compose': {
@@ -82,17 +91,23 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
         InputValidator.validateBPM(args.tempo);
       }
 
-      await ctx.ensureInitialized();
+      // Auto-init only the default session. Named sessions must be
+      // created via `create_session` first — ctx.getController(sid)
+      // throws if missing, which the dispatcher renders as err('business').
+      if (!sid) {
+        await ctx.ensureInitialized();
+      }
+      const controller = ctx.getController(sid);
 
       const tempo = args.tempo || defaultTempo(args.style);
       const key = args.key || 'C';
       const pattern = ctx.generator.generateCompletePattern(args.style, key, tempo);
 
-      await ctx.controller.writePattern(pattern);
+      await controller.writePattern(pattern);
 
       const shouldPlay = args.auto_play !== false;
       if (shouldPlay) {
-        await ctx.controller.play();
+        await controller.play();
       }
 
       const response: {

--- a/src/server/tools/diagnostics.ts
+++ b/src/server/tools/diagnostics.ts
@@ -12,13 +12,22 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
+    // Server-wide metric; session_id not applicable.
     name: 'performance_report',
     description: 'Get performance metrics and bottlenecks',
     inputSchema: { type: 'object', properties: {} },
   },
   {
+    // Server-wide; session_id not applicable.
     name: 'memory_usage',
     description: 'Get current memory usage statistics',
     inputSchema: { type: 'object', properties: {} },
@@ -30,29 +39,31 @@ export const tools: Tool[] = [
       type: 'object',
       properties: {
         filename: { type: 'string', description: 'Optional filename for screenshot' },
+        ...SESSION_ID_PROP,
       },
     },
   },
   {
     name: 'status',
     description: 'Get current browser and playback status (quick state check)',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'diagnostics',
     description: 'Get detailed browser diagnostics including cache, errors, and performance',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'show_errors',
     description: 'Display captured console errors and warnings from Strudel',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
 ];
 
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
   switch (name) {
     case 'performance_report': {
       const report = ctx.perfMonitor.getReport();
@@ -66,28 +77,29 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
     }
 
     case 'screenshot': {
-      if (!ctx.isInitialized()) {
+      if (!sid && !ctx.isInitialized()) {
         return 'Browser not initialized. Run init first.';
       }
-      return await ctx.controller.takeScreenshot(args?.filename);
+      return await ctx.getController(sid).takeScreenshot(args?.filename);
     }
 
     case 'status':
-      return ctx.controller.getStatus();
+      return ctx.getController(sid).getStatus();
 
     case 'diagnostics': {
-      if (!ctx.isInitialized()) {
+      if (!sid && !ctx.isInitialized()) {
         return {
           initialized: false,
           message: 'Browser not initialized. Run init first for full diagnostics.',
         };
       }
-      return await ctx.controller.getDiagnostics();
+      return await ctx.getController(sid).getDiagnostics();
     }
 
     case 'show_errors': {
-      const errors = ctx.controller.getConsoleErrors();
-      const warnings = ctx.controller.getConsoleWarnings();
+      const controller = ctx.getController(sid);
+      const errors = controller.getConsoleErrors();
+      const warnings = controller.getConsoleWarnings();
 
       if (errors.length === 0 && warnings.length === 0) {
         return 'No errors or warnings captured.';

--- a/src/server/tools/editor.ts
+++ b/src/server/tools/editor.ts
@@ -11,6 +11,13 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'write',
@@ -21,6 +28,7 @@ export const tools: Tool[] = [
         pattern: { type: 'string', description: 'Pattern code' },
         auto_play: { type: 'boolean', description: 'Start playback immediately after writing (default: false)' },
         validate: { type: 'boolean', description: 'Validate pattern before writing (default: true)' },
+        ...SESSION_ID_PROP,
       },
       required: ['pattern'],
     },
@@ -30,7 +38,7 @@ export const tools: Tool[] = [
     description: 'Append code to current pattern',
     inputSchema: {
       type: 'object',
-      properties: { code: { type: 'string', description: 'Code to append' } },
+      properties: { code: { type: 'string', description: 'Code to append' }, ...SESSION_ID_PROP },
       required: ['code'],
     },
   },
@@ -42,6 +50,7 @@ export const tools: Tool[] = [
       properties: {
         position: { type: 'number', description: 'Line number' },
         code: { type: 'string', description: 'Code to insert' },
+        ...SESSION_ID_PROP,
       },
       required: ['position', 'code'],
     },
@@ -54,6 +63,7 @@ export const tools: Tool[] = [
       properties: {
         search: { type: 'string', description: 'Text to replace' },
         replace: { type: 'string', description: 'Replacement text' },
+        ...SESSION_ID_PROP,
       },
       required: ['search', 'replace'],
     },
@@ -61,26 +71,32 @@ export const tools: Tool[] = [
   {
     name: 'clear',
     description: 'Clear the editor',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'get_pattern',
     description: 'Get current pattern code',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
 ];
 
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
+  if (!sid && !ctx.isInitialized()) {
+    return 'Browser not initialized. Run init first.';
+  }
   switch (name) {
     case 'write': {
       InputValidator.validateStringLength(args.pattern, 'pattern', 10000, true);
 
+      const controller = ctx.getController(sid);
+
       // Validate pattern if requested (default: true) — issue #40
-      if (args.validate !== false && ctx.isInitialized() && typeof ctx.controller.validatePattern === 'function') {
+      if (args.validate !== false && typeof controller.validatePattern === 'function') {
         try {
-          const validation = await ctx.controller.validatePattern(args.pattern);
+          const validation = await controller.validatePattern(args.pattern);
           if (validation && !validation.valid) {
             return {
               success: false,
@@ -95,11 +111,11 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
         }
       }
 
-      const writeResult = await ctx.writePatternSafe(args.pattern);
+      const writeResult = await ctx.writePatternSafe(args.pattern, sid);
 
       // Auto-play if requested — issue #38
-      if (args.auto_play && ctx.isInitialized()) {
-        await ctx.controller.play();
+      if (args.auto_play) {
+        await controller.play();
         return `${writeResult}. Playing.`;
       }
       return writeResult;
@@ -107,33 +123,33 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
 
     case 'append': {
       InputValidator.validateStringLength(args.code, 'code', 10000, true);
-      const current = await ctx.getCurrentPatternSafe();
-      return await ctx.writePatternSafe(current + '\n' + args.code);
+      const current = await ctx.getCurrentPatternSafe(sid);
+      return await ctx.writePatternSafe(current + '\n' + args.code, sid);
     }
 
     case 'insert': {
       InputValidator.validatePositiveInteger(args.position, 'position');
       InputValidator.validateStringLength(args.code, 'code', 10000, true);
-      const lines = (await ctx.getCurrentPatternSafe()).split('\n');
+      const lines = (await ctx.getCurrentPatternSafe(sid)).split('\n');
       lines.splice(args.position, 0, args.code);
-      return await ctx.writePatternSafe(lines.join('\n'));
+      return await ctx.writePatternSafe(lines.join('\n'), sid);
     }
 
     case 'replace': {
       InputValidator.validateStringLength(args.search, 'search', 1000, true);
       InputValidator.validateStringLength(args.replace, 'replace', 10000, true);
-      const pattern = await ctx.getCurrentPatternSafe();
+      const pattern = await ctx.getCurrentPatternSafe(sid);
       // Escape $ in replacement to prevent special sequence injection ($&, $1, $', etc.)
       const safeReplacement = args.replace.replace(/\$/g, '$$$$');
       const replaced = pattern.replace(args.search, safeReplacement);
-      return await ctx.writePatternSafe(replaced);
+      return await ctx.writePatternSafe(replaced, sid);
     }
 
     case 'clear':
-      return await ctx.writePatternSafe('');
+      return await ctx.writePatternSafe('', sid);
 
     case 'get_pattern':
-      return await ctx.getCurrentPatternSafe();
+      return await ctx.getCurrentPatternSafe(sid);
 
     default:
       throw new Error(`editor module does not handle tool: ${name}`);

--- a/src/server/tools/generate.ts
+++ b/src/server/tools/generate.ts
@@ -17,6 +17,13 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'generate_pattern',
@@ -28,6 +35,7 @@ export const tools: Tool[] = [
         key: { type: 'string', description: 'Musical key' },
         bpm: { type: 'number', description: 'Tempo in BPM' },
         auto_play: { type: 'boolean', description: 'Start playback immediately (default: false)' },
+        ...SESSION_ID_PROP,
       },
       required: ['style'],
     },
@@ -40,6 +48,7 @@ export const tools: Tool[] = [
       properties: {
         style: { type: 'string', description: 'Drum style' },
         complexity: { type: 'number', description: 'Complexity (0-1)' },
+        ...SESSION_ID_PROP,
       },
       required: ['style'],
     },
@@ -52,6 +61,7 @@ export const tools: Tool[] = [
       properties: {
         key: { type: 'string', description: 'Musical key' },
         style: { type: 'string', description: 'Bass style' },
+        ...SESSION_ID_PROP,
       },
       required: ['key', 'style'],
     },
@@ -65,6 +75,7 @@ export const tools: Tool[] = [
         scale: { type: 'string', description: 'Scale name' },
         root: { type: 'string', description: 'Root note' },
         length: { type: 'number', description: 'Number of notes' },
+        ...SESSION_ID_PROP,
       },
       required: ['scale', 'root'],
     },
@@ -89,6 +100,7 @@ export const tools: Tool[] = [
       properties: {
         key: { type: 'string', description: 'Key' },
         style: { type: 'string', description: 'Style (pop/jazz/blues/etc)' },
+        ...SESSION_ID_PROP,
       },
       required: ['key', 'style'],
     },
@@ -102,6 +114,7 @@ export const tools: Tool[] = [
         hits: { type: 'number', description: 'Number of hits' },
         steps: { type: 'number', description: 'Total steps' },
         sound: { type: 'string', description: 'Sound to use' },
+        ...SESSION_ID_PROP,
       },
       required: ['hits', 'steps'],
     },
@@ -114,6 +127,7 @@ export const tools: Tool[] = [
       properties: {
         sounds: { type: 'array', items: { type: 'string' }, description: 'Sounds to use' },
         patterns: { type: 'array', items: { type: 'number' }, description: 'Pattern numbers' },
+        ...SESSION_ID_PROP,
       },
       required: ['sounds', 'patterns'],
     },
@@ -126,6 +140,7 @@ export const tools: Tool[] = [
       properties: {
         style: { type: 'string', description: 'Fill style' },
         bars: { type: 'number', description: 'Number of bars' },
+        ...SESSION_ID_PROP,
       },
       required: ['style'],
     },
@@ -134,13 +149,14 @@ export const tools: Tool[] = [
 
 export const toolNames = new Set(tools.map(t => t.name));
 
-async function appendOrSet(generated: string, ctx: ToolContext): Promise<void> {
-  const current = await ctx.getCurrentPatternSafe();
+async function appendOrSet(generated: string, ctx: ToolContext, sessionId?: string): Promise<void> {
+  const current = await ctx.getCurrentPatternSafe(sessionId);
   const combined = current ? current + '\n' + generated : generated;
-  await ctx.writePatternSafe(combined);
+  await ctx.writePatternSafe(combined, sessionId);
 }
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
   switch (name) {
     case 'generate_pattern': {
       InputValidator.validateStringLength(args.style, 'style', 100, false);
@@ -152,10 +168,10 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
         args.key || 'C',
         args.bpm || 120,
       );
-      await ctx.writePatternSafe(generated);
+      await ctx.writePatternSafe(generated, sid);
 
-      if (args.auto_play && ctx.isInitialized()) {
-        await ctx.controller.play();
+      if (args.auto_play && (sid || ctx.isInitialized())) {
+        await ctx.getController(sid).play();
         return `Generated ${args.style} pattern. Playing.`;
       }
       return `Generated ${args.style} pattern`;
@@ -165,7 +181,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       InputValidator.validateStringLength(args.style, 'style', 100, false);
       if (args.complexity !== undefined) InputValidator.validateNormalizedValue(args.complexity, 'complexity');
       const drums = ctx.generator.generateDrumPattern(args.style, args.complexity || 0.5);
-      await appendOrSet(drums, ctx);
+      await appendOrSet(drums, ctx, sid);
       return `Generated ${args.style} drums`;
     }
 
@@ -173,7 +189,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       InputValidator.validateRootNote(args.key);
       InputValidator.validateStringLength(args.style, 'style', 100, false);
       const bass = ctx.generator.generateBassline(args.key, args.style);
-      await appendOrSet(bass, ctx);
+      await appendOrSet(bass, ctx, sid);
       return `Generated ${args.style} bassline in ${args.key}`;
     }
 
@@ -183,11 +199,12 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       if (args.length !== undefined) InputValidator.validatePositiveInteger(args.length, 'length');
       const scale = ctx.theory.generateScale(args.root, args.scale);
       const melody = ctx.generator.generateMelody(scale, args.length || 8);
-      await appendOrSet(melody, ctx);
+      await appendOrSet(melody, ctx, sid);
       return `Generated melody in ${args.root} ${args.scale}`;
     }
 
     case 'generate_scale': {
+      // Pure music-theory query; no session needed.
       InputValidator.validateRootNote(args.root);
       InputValidator.validateScaleName(args.scale);
       const notes = ctx.theory.generateScale(args.root, args.scale);
@@ -199,7 +216,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       InputValidator.validateChordStyle(args.style);
       const progression = ctx.theory.generateChordProgression(args.key, args.style);
       const chordPattern = ctx.generator.generateChords(progression);
-      await appendOrSet(chordPattern, ctx);
+      await appendOrSet(chordPattern, ctx, sid);
       return `Generated ${args.style} progression in ${args.key}: ${progression}`;
     }
 
@@ -211,7 +228,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
         args.steps,
         args.sound || 'bd',
       );
-      await appendOrSet(euclidean, ctx);
+      await appendOrSet(euclidean, ctx, sid);
       return `Generated Euclidean rhythm (${args.hits}/${args.steps})`;
     }
 
@@ -219,7 +236,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       args.sounds.forEach((s: string) => InputValidator.validateStringLength(s, 'sound', 100, false));
       args.patterns.forEach((p: number) => InputValidator.validatePositiveInteger(p, 'pattern'));
       const poly = ctx.generator.generatePolyrhythm(args.sounds, args.patterns);
-      await appendOrSet(poly, ctx);
+      await appendOrSet(poly, ctx, sid);
       return 'Generated polyrhythm';
     }
 
@@ -227,7 +244,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       InputValidator.validateStringLength(args.style, 'style', 100, false);
       if (args.bars !== undefined) InputValidator.validatePositiveInteger(args.bars, 'bars');
       const fill = ctx.generator.generateFill(args.style, args.bars || 1);
-      await appendOrSet(fill, ctx);
+      await appendOrSet(fill, ctx, sid);
       return `Generated ${args.bars || 1} bar fill`;
     }
 

--- a/src/server/tools/history.ts
+++ b/src/server/tools/history.ts
@@ -15,16 +15,23 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session. Note: undo/redo/history stacks are currently server-wide; only the read/write target changes.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'undo',
     description: 'Undo last action',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'redo',
     description: 'Redo action',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'list_history',
@@ -43,6 +50,7 @@ export const tools: Tool[] = [
       type: 'object',
       properties: {
         id: { type: 'number', description: 'History entry ID to restore' },
+        ...SESSION_ID_PROP,
       },
       required: ['id'],
     },
@@ -55,6 +63,7 @@ export const tools: Tool[] = [
       properties: {
         id1: { type: 'number', description: 'First pattern ID' },
         id2: { type: 'number', description: 'Second pattern ID (default: current pattern)' },
+        ...SESSION_ID_PROP,
       },
       required: ['id1'],
     },
@@ -111,31 +120,34 @@ function summarizeDiff(a: string, b: string): {
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const { undoStack, redoStack, historyStack, maxHistory } = ctx.history;
+  const sid: string | undefined = args?.session_id;
 
   switch (name) {
     case 'undo': {
-      if (!ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
       if (undoStack.length === 0) return 'Nothing to undo';
+      const controller = ctx.getController(sid);
 
-      const current = await ctx.controller.getCurrentPattern();
+      const current = await controller.getCurrentPattern();
       redoStack.push(current);
       if (redoStack.length > maxHistory) redoStack.shift();
 
       const previous = undoStack.pop()!;
-      await ctx.controller.writePattern(previous);
+      await controller.writePattern(previous);
       return 'Undone';
     }
 
     case 'redo': {
-      if (!ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
       if (redoStack.length === 0) return 'Nothing to redo';
+      const controller = ctx.getController(sid);
 
-      const current = await ctx.controller.getCurrentPattern();
+      const current = await controller.getCurrentPattern();
       undoStack.push(current);
       if (undoStack.length > maxHistory) undoStack.shift();
 
       const next = redoStack.pop()!;
-      await ctx.controller.writePattern(next);
+      await controller.writePattern(next);
       return 'Redone';
     }
 
@@ -159,18 +171,19 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
     }
 
     case 'restore_history': {
-      if (!ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+      const controller = ctx.getController(sid);
 
       const entry = historyStack.find(e => e.id === args.id);
       if (!entry) {
         return `History entry #${args.id} not found. Use list_history to see available entries.`;
       }
 
-      const current = await ctx.controller.getCurrentPattern();
+      const current = await controller.getCurrentPattern();
       undoStack.push(current);
       if (undoStack.length > maxHistory) undoStack.shift();
 
-      await ctx.controller.writePattern(entry.pattern);
+      await controller.writePattern(entry.pattern);
       return `Restored pattern from history #${args.id} (${formatTimeAgo(entry.timestamp)})`;
     }
 
@@ -186,7 +199,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
         second = b.pattern;
         label = `#${args.id2}`;
       } else {
-        second = await ctx.getCurrentPatternSafe();
+        second = await ctx.getCurrentPatternSafe(sid);
         label = 'current';
       }
 

--- a/src/server/tools/playback.ts
+++ b/src/server/tools/playback.ts
@@ -3,44 +3,55 @@
  *
  * Owns (3 tools): play, pause, stop. Post-consolidation target
  * (#110 audit, #120 epic): single `playback` tool with action enum.
- * For now we keep the individual verbs and only extract them out of
- * server.ts.
  *
- * Initialization checks happen upstream via requiresInitialization()
- * in StrudelMCPServer — handlers here assume the browser is ready.
+ * Each tool accepts an optional `session_id` (#108). Omitting it
+ * targets the default/legacy session; an explicit id routes through
+ * SessionManager and errors if the session doesn't exist.
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'play',
     description: 'Start playing pattern',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'pause',
     description: 'Pause playback',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'stop',
     description: 'Stop playback',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
 ];
 
 export const toolNames = new Set(tools.map(t => t.name));
 
-export async function execute(name: string, _args: any, ctx: ToolContext): Promise<unknown> {
+export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
+  if (!sid && !ctx.isInitialized()) {
+    return 'Browser not initialized. Run init first.';
+  }
+  const controller = ctx.getController(sid);
   switch (name) {
     case 'play':
-      return await ctx.controller.play();
+      return await controller.play();
 
     case 'pause':
     case 'stop':
-      return await ctx.controller.stop();
+      return await controller.stop();
 
     default:
       throw new Error(`playback module does not handle tool: ${name}`);

--- a/src/server/tools/storage.ts
+++ b/src/server/tools/storage.ts
@@ -4,12 +4,23 @@
  * Owns (3 tools): save, load, list. Post-consolidation target per the
  * #110 audit: single `pattern_store` tool with `action` enum + params,
  * which also resolves the `list` / `list_sessions` naming collision.
- * For now we keep the individual verbs.
+ *
+ * save/load route through the requested session's pattern (#108) but
+ * the on-disk catalog is server-wide — saving from session A and
+ * loading into session B works fine and is the intended cross-session
+ * primitive. `list` is purely on-disk and has no session.
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
+
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). save/load source/target the named session\'s current pattern; the on-disk catalog is shared.',
+  },
+};
 
 export const tools: Tool[] = [
   {
@@ -20,6 +31,7 @@ export const tools: Tool[] = [
       properties: {
         name: { type: 'string', description: 'Pattern name' },
         tags: { type: 'array', items: { type: 'string' } },
+        ...SESSION_ID_PROP,
       },
       required: ['name'],
     },
@@ -31,6 +43,7 @@ export const tools: Tool[] = [
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Pattern name' },
+        ...SESSION_ID_PROP,
       },
       required: ['name'],
     },
@@ -50,10 +63,11 @@ export const tools: Tool[] = [
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
   switch (name) {
     case 'save': {
       InputValidator.validateStringLength(args.name, 'name', 255, false);
-      const toSave = await ctx.getCurrentPatternSafe();
+      const toSave = await ctx.getCurrentPatternSafe(sid);
       if (!toSave) {
         return 'No pattern to save';
       }
@@ -65,7 +79,7 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       InputValidator.validateStringLength(args.name, 'name', 255, false);
       const saved = await ctx.store.load(args.name);
       if (saved) {
-        await ctx.writePatternSafe(saved.content);
+        await ctx.writePatternSafe(saved.content, sid);
         return `Loaded pattern "${args.name}"`;
       }
       return `Pattern "${args.name}" not found`;

--- a/src/server/tools/transform.ts
+++ b/src/server/tools/transform.ts
@@ -74,27 +74,34 @@ function transposePattern(pattern: string, semitones: number): string {
   });
 }
 
+const SESSION_ID_PROP = {
+  session_id: {
+    type: 'string',
+    description: 'Optional session ID (#108). Omit to use default session.',
+  },
+};
+
 export const tools: Tool[] = [
   {
     name: 'transpose',
     description: 'Transpose notes by semitones',
     inputSchema: {
       type: 'object',
-      properties: { semitones: { type: 'number', description: 'Semitones to transpose' } },
+      properties: { semitones: { type: 'number', description: 'Semitones to transpose' }, ...SESSION_ID_PROP },
       required: ['semitones'],
     },
   },
   {
     name: 'reverse',
     description: 'Reverse pattern',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'stretch',
     description: 'Time stretch pattern',
     inputSchema: {
       type: 'object',
-      properties: { factor: { type: 'number', description: 'Stretch factor' } },
+      properties: { factor: { type: 'number', description: 'Stretch factor' }, ...SESSION_ID_PROP },
       required: ['factor'],
     },
   },
@@ -103,7 +110,7 @@ export const tools: Tool[] = [
     description: 'Quantize to grid',
     inputSchema: {
       type: 'object',
-      properties: { grid: { type: 'string', description: 'Grid size (e.g., "1/16")' } },
+      properties: { grid: { type: 'string', description: 'Grid size (e.g., "1/16")' }, ...SESSION_ID_PROP },
       required: ['grid'],
     },
   },
@@ -112,7 +119,7 @@ export const tools: Tool[] = [
     description: 'Add human timing variation',
     inputSchema: {
       type: 'object',
-      properties: { amount: { type: 'number', description: 'Humanization amount (0-1)' } },
+      properties: { amount: { type: 'number', description: 'Humanization amount (0-1)' }, ...SESSION_ID_PROP },
     },
   },
   {
@@ -120,7 +127,7 @@ export const tools: Tool[] = [
     description: 'Create pattern variations',
     inputSchema: {
       type: 'object',
-      properties: { type: { type: 'string', description: 'Variation type (subtle/moderate/extreme/glitch/evolving)' } },
+      properties: { type: { type: 'string', description: 'Variation type (subtle/moderate/extreme/glitch/evolving)' }, ...SESSION_ID_PROP },
     },
   },
   {
@@ -131,6 +138,7 @@ export const tools: Tool[] = [
       properties: {
         effect: { type: 'string', description: 'Effect name' },
         params: { type: 'string', description: 'Effect parameters' },
+        ...SESSION_ID_PROP,
       },
       required: ['effect'],
     },
@@ -140,7 +148,7 @@ export const tools: Tool[] = [
     description: 'Remove effect',
     inputSchema: {
       type: 'object',
-      properties: { effect: { type: 'string', description: 'Effect to remove' } },
+      properties: { effect: { type: 'string', description: 'Effect to remove' }, ...SESSION_ID_PROP },
       required: ['effect'],
     },
   },
@@ -149,7 +157,7 @@ export const tools: Tool[] = [
     description: 'Set BPM',
     inputSchema: {
       type: 'object',
-      properties: { bpm: { type: 'number', description: 'Tempo in BPM' } },
+      properties: { bpm: { type: 'number', description: 'Tempo in BPM' }, ...SESSION_ID_PROP },
       required: ['bpm'],
     },
   },
@@ -158,7 +166,7 @@ export const tools: Tool[] = [
     description: 'Add swing to pattern',
     inputSchema: {
       type: 'object',
-      properties: { amount: { type: 'number', description: 'Swing amount (0-1)' } },
+      properties: { amount: { type: 'number', description: 'Swing amount (0-1)' }, ...SESSION_ID_PROP },
       required: ['amount'],
     },
   },
@@ -170,6 +178,7 @@ export const tools: Tool[] = [
       properties: {
         scale: { type: 'string', description: 'Scale name' },
         root: { type: 'string', description: 'Root note' },
+        ...SESSION_ID_PROP,
       },
       required: ['scale', 'root'],
     },
@@ -187,6 +196,7 @@ export const tools: Tool[] = [
         },
         intensity: { type: 'number', minimum: 0, maximum: 1, description: 'How strongly to apply the mood transformation (0-1, default: 0.5)' },
         auto_play: { type: 'boolean', description: 'Start playback after transformation (default: true)' },
+        ...SESSION_ID_PROP,
       },
       required: ['target_mood'],
     },
@@ -196,7 +206,7 @@ export const tools: Tool[] = [
     description: 'Adjust the overall energy level of the current pattern on a 0-10 scale. 0: minimal/ambient, 1-2: sparse, 3-4: light/relaxed, 5-6: normal/moderate, 7-8: driving/intense, 9-10: maximum. Auto-plays after applying energy level.',
     inputSchema: {
       type: 'object',
-      properties: { level: { type: 'number', description: 'Energy level from 0 (minimal) to 10 (maximum)' } },
+      properties: { level: { type: 'number', description: 'Energy level from 0 (minimal) to 10 (maximum)' }, ...SESSION_ID_PROP },
       required: ['level'],
     },
   },
@@ -205,7 +215,7 @@ export const tools: Tool[] = [
     description: 'Incrementally refine the current pattern with simple directional commands. Supports: faster/slower (tempo), louder/quieter (gain), brighter/darker (filter cutoff), "more reverb"/drier (reverb). Auto-plays after applying refinement.',
     inputSchema: {
       type: 'object',
-      properties: { direction: { type: 'string', description: 'Refinement direction: faster, slower, louder, quieter, brighter, darker, "more reverb", or drier' } },
+      properties: { direction: { type: 'string', description: 'Refinement direction: faster, slower, louder, quieter, brighter, darker, "more reverb", or drier' }, ...SESSION_ID_PROP },
       required: ['direction'],
     },
   },
@@ -214,109 +224,113 @@ export const tools: Tool[] = [
 export const toolNames = new Set(tools.map(t => t.name));
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  const sid: string | undefined = args?.session_id;
+  if (!sid && !ctx.isInitialized()) {
+    return 'Browser not initialized. Run init first.';
+  }
   switch (name) {
     case 'transpose': {
       if (typeof args.semitones !== 'number' || !Number.isInteger(args.semitones)) {
         throw new Error('Semitones must be an integer');
       }
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(transposePattern(p, args.semitones));
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(transposePattern(p, args.semitones), sid);
       return `Transposed ${args.semitones} semitones`;
     }
 
     case 'reverse': {
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(p + '.rev');
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(p + '.rev', sid);
       return 'Pattern reversed';
     }
 
     case 'stretch': {
       InputValidator.validateGain(args.factor);
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(p + `.slow(${args.factor})`);
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(p + `.slow(${args.factor})`, sid);
       return `Stretched by factor of ${args.factor}`;
     }
 
     case 'quantize': {
       InputValidator.validateStringLength(args.grid, 'grid', 50, false);
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(p + `.struct("${args.grid}")`);
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(p + `.struct("${args.grid}")`, sid);
       return `Quantized to ${args.grid} grid`;
     }
 
     case 'humanize': {
       if (args.amount !== undefined) InputValidator.validateNormalizedValue(args.amount, 'amount');
-      const p = await ctx.getCurrentPatternSafe();
+      const p = await ctx.getCurrentPatternSafe(sid);
       const amt = args.amount || 0.01;
-      await ctx.writePatternSafe(p + `.nudge(rand.range(-${amt}, ${amt}))`);
+      await ctx.writePatternSafe(p + `.nudge(rand.range(-${amt}, ${amt}))`, sid);
       return 'Added human timing';
     }
 
     case 'generate_variation': {
-      const p = await ctx.getCurrentPatternSafe();
+      const p = await ctx.getCurrentPatternSafe(sid);
       const varied = ctx.generator.generateVariation(p, args.type || 'subtle');
-      await ctx.writePatternSafe(varied);
+      await ctx.writePatternSafe(varied, sid);
       return `Added ${args.type || 'subtle'} variation`;
     }
 
     case 'add_effect': {
       InputValidator.validateStringLength(args.effect, 'effect', 100, false);
       if (args.params) InputValidator.validateStringLength(args.params, 'params', 1000, true);
-      const p = await ctx.getCurrentPatternSafe();
+      const p = await ctx.getCurrentPatternSafe(sid);
       const withEffect = args.params
         ? p + `.${args.effect}(${args.params})`
         : p + `.${args.effect}()`;
-      await ctx.writePatternSafe(withEffect);
+      await ctx.writePatternSafe(withEffect, sid);
       return `Added ${args.effect} effect`;
     }
 
     case 'remove_effect': {
       InputValidator.validateStringLength(args.effect, 'effect', 100, false);
-      const p = await ctx.getCurrentPatternSafe();
+      const p = await ctx.getCurrentPatternSafe(sid);
       const regex = new RegExp(`\\.${args.effect}\\([^)]*\\)`, 'g');
       const stripped = p.replace(regex, '');
       if (stripped === p) return `No ${args.effect} effect found to remove`;
-      await ctx.writePatternSafe(stripped);
+      await ctx.writePatternSafe(stripped, sid);
       return `Removed ${args.effect} effect`;
     }
 
     case 'set_tempo': {
       InputValidator.validateBPM(args.bpm);
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(`setcpm(${args.bpm})\n${p}`);
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(`setcpm(${args.bpm})\n${p}`, sid);
       return `Set tempo to ${args.bpm} BPM`;
     }
 
     case 'add_swing': {
       InputValidator.validateNormalizedValue(args.amount, 'amount');
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(p + `.swing(${args.amount})`);
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(p + `.swing(${args.amount})`, sid);
       return `Added swing: ${args.amount}`;
     }
 
     case 'apply_scale': {
       InputValidator.validateStringLength(args.scale, 'scale', 50, false);
       InputValidator.validateRootNote(args.root);
-      const p = await ctx.getCurrentPatternSafe();
-      await ctx.writePatternSafe(p + `.scale("${args.root}:${args.scale}")`);
+      const p = await ctx.getCurrentPatternSafe(sid);
+      await ctx.writePatternSafe(p + `.scale("${args.root}:${args.scale}")`, sid);
       return `Applied ${args.root} ${args.scale} scale`;
     }
 
     case 'shift_mood':
-      return await shiftMood(args, ctx);
+      return await shiftMood(args, ctx, sid);
 
     case 'set_energy':
-      return await setEnergyLevel(args.level, ctx);
+      return await setEnergyLevel(args.level, ctx, sid);
 
     case 'refine':
-      return await refinePattern(args.direction, ctx);
+      return await refinePattern(args.direction, ctx, sid);
 
     default:
       throw new Error(`transform module does not handle tool: ${name}`);
   }
 }
 
-async function shiftMood(args: any, ctx: ToolContext): Promise<unknown> {
+async function shiftMood(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
   const mood = args.target_mood?.toLowerCase()?.trim();
   const profile = MOOD_PROFILES[mood];
   if (!profile) {
@@ -326,7 +340,7 @@ async function shiftMood(args: any, ctx: ToolContext): Promise<unknown> {
     };
   }
 
-  const pattern = await ctx.getCurrentPatternSafe();
+  const pattern = await ctx.getCurrentPatternSafe(sid);
   if (!pattern || pattern.trim().length === 0) {
     return { success: false, error: 'No pattern to transform. Write a pattern first.' };
   }
@@ -375,21 +389,21 @@ async function shiftMood(args: any, ctx: ToolContext): Promise<unknown> {
     applied.push(`gain ${profile.gainMod > 0 ? '+' : ''}${Math.round(profile.gainMod * 100 * intensity)}%`);
   }
 
-  await ctx.writePatternSafe(result);
+  await ctx.writePatternSafe(result, sid);
 
-  if (args.auto_play !== false && ctx.isInitialized()) {
-    await ctx.controller.play();
+  if (args.auto_play !== false && (sid || ctx.isInitialized())) {
+    await ctx.getController(sid).play();
   }
 
   return { success: true, target_mood: mood, intensity, applied_effects: applied };
 }
 
-async function setEnergyLevel(level: number, ctx: ToolContext): Promise<unknown> {
+async function setEnergyLevel(level: number, ctx: ToolContext, sid?: string): Promise<unknown> {
   if (level < 0 || level > 10 || !Number.isInteger(level)) {
     return { success: false, error: 'Energy level must be an integer from 0 to 10.' };
   }
 
-  const pattern = await ctx.getCurrentPatternSafe();
+  const pattern = await ctx.getCurrentPatternSafe(sid);
   if (!pattern || pattern.trim().length === 0) {
     return { success: false, error: 'No pattern to adjust. Write a pattern first.' };
   }
@@ -399,14 +413,14 @@ async function setEnergyLevel(level: number, ctx: ToolContext): Promise<unknown>
   if (config.densityAdjust) result += config.densityAdjust;
   result += `.room(${config.roomAmount})`;
 
-  await ctx.writePatternSafe(result);
-  if (ctx.isInitialized()) await ctx.controller.play();
+  await ctx.writePatternSafe(result, sid);
+  if (sid || ctx.isInitialized()) await ctx.getController(sid).play();
 
   return { success: true, level, description: config.description };
 }
 
-async function refinePattern(direction: string, ctx: ToolContext): Promise<unknown> {
-  const pattern = await ctx.getCurrentPatternSafe();
+async function refinePattern(direction: string, ctx: ToolContext, sid?: string): Promise<unknown> {
+  const pattern = await ctx.getCurrentPatternSafe(sid);
   if (!pattern || pattern.trim().length === 0) {
     return { success: false, error: 'No pattern to refine. Write a pattern first.' };
   }
@@ -429,8 +443,8 @@ async function refinePattern(direction: string, ctx: ToolContext): Promise<unkno
       };
   }
 
-  await ctx.writePatternSafe(pattern + modification);
-  if (ctx.isInitialized()) await ctx.controller.play();
+  await ctx.writePatternSafe(pattern + modification, sid);
+  if (sid || ctx.isInitialized()) await ctx.getController(sid).play();
 
   return { success: true, direction: dir, applied: modification };
 }

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -71,8 +71,23 @@ export interface ToolContext {
    * auto-init rather than refusing without setup.
    */
   ensureInitialized(): Promise<void>;
-  getCurrentPatternSafe(): Promise<string>;
-  writePatternSafe(pattern: string): Promise<string>;
+  /**
+   * Resolves a StrudelController for the requested session (#108).
+   *
+   * Semantics:
+   *   - `undefined` (no session_id) → legacy/default controller; preserves
+   *     single-user behaviour for callers that don't know about sessions.
+   *   - explicit string → SessionManager.getSession(id); **throws** if the
+   *     session doesn't exist. Named sessions must be created via the
+   *     `create_session` tool before use.
+   *
+   * Tools should call this instead of touching `controller` directly when
+   * they're stateful-on-the-browser. The dispatcher wraps the throw into
+   * `err('business', 'Session 'X' not found...')` for MCP clients.
+   */
+  getController(sessionId?: string): StrudelController;
+  getCurrentPatternSafe(sessionId?: string): Promise<string>;
+  writePatternSafe(pattern: string, sessionId?: string): Promise<string>;
 }
 
 /**


### PR DESCRIPTION
Closes #108. Closes #141.

Multi-session was half-shipped: \`SessionManager\` existed with caps + idle timeout + lifecycle tools, but no actual tool consulted \`session_id\`, so every controller call hit the legacy single page. This PR threads \`session_id\` through every browser-touching tool so two agents driving the same MCP connection can hold distinct sessions.

## Design decisions (signed off in #108)

| # | Choice |
|---|---|
| 1A | Explicit \`session_id\` arg on every stateful tool |
| 2A | Omitting \`session_id\` falls back to default/legacy controller |
| 3A | Capped sessions (5) refuse with \`err('business')\`; no auto-evict |
| 4A+B | Every browser-touching tool AND generation tools get \`session_id\` |
| 5A | Optional arg, no protocol version bump |

## What changed

- **\`ToolContext\`**: \`getController(sessionId?)\` — legacy fallback when omitted; SessionManager strict lookup when present (throws if missing). \`getCurrentPatternSafe\` / \`writePatternSafe\` are now session-aware; named sessions skip the pre-init pattern stash.
- **All 10 browser-touching tool modules**: add \`session_id\` to every affected inputSchema; replace \`ctx.controller.*\` with \`ctx.getController(sid).*\`. Modules that previously relied on the pre-flight init check now do their own.
- **Pure tools** that don't touch the browser (\`generate_scale\`, the four local-engine tools, \`list\`, \`list_history\`, \`performance_report\`, \`memory_usage\`, \`list_sessions\`, \`init\`) stay unchanged.
- **Remove dead \`requiresInitialization()\` pre-flight (#141)**: the hardcoded tool-name list had drifted as tools moved between modules and was silently wrong for explicit \`session_id\` (returned \"Browser not initialized\" instead of \"Session 'X' not found\"). Each module's \`execute()\` now owns the init check.

**Coverage**: 59/70 tools accept \`session_id\`; 11 are intentionally session-free.

## Tests

- **New** \`src/__tests__/unit/MultiSession.test.ts\` — 8 cases covering two-session isolation, legacy fallback, missing-session throw, per-tool routing, schema validation
- **Updated** \`MCPServer.integration.test.ts\` (2 cases) — old assertions referenced the deleted \`requiresInitialization()\` method and the old pre-flight error string
- **1579 unit/integration tests pass** (was 1571 → +8 multi-session)
- tsc clean. Lint clean (0 errors, 126 warnings).
- End-to-end verified via stdio:
  \`\`\`json
  // tools/call play with explicit non-existent session_id
  { \"ok\": false, \"errorCategory\": \"business\", \"isRetryable\": false,
    \"message\": \"Session 'non-existent' not found. Create it first with create_session.\" }
  \`\`\`

## Known limitations (filed as follow-ups)

- Undo/redo/history stacks are server-wide; per-session stacks tracked in #140 envelope-migration work (and noted in history.ts schema)
- AudioCaptureService is a server-wide singleton; concurrent captures across sessions will conflict — noted in capture.ts schema, separate refactor warranted

🤖 Generated with [Claude Code](https://claude.com/claude-code)