### PR TITLE
feat(#143): consolidate save/load/list → pattern_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,9 @@ FUTURE_ENHANCEMENTS.md
 # Development/testing scripts
 play-*.js
 
-# Local Claude settings
+# Local Claude settings + harness state
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Nexus agents config (local setup)
 nexus-agents.yaml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-70-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-71-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -197,7 +197,7 @@ Then ask Claude:
 
 <!-- TOOLS:START -->
 
-**70 tools** across 15 categories:
+**71 tools** across 15 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -236,9 +236,9 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `save` | Save pattern with metadata |
-| `load` | Load saved pattern |
-| `list` | List saved patterns |
+| `save` | [DEPRECATED — use pattern_store({ action: "save" }) instead] Save pattern with metadata |
+| `load` | [DEPRECATED — use pattern_store({ action: "load" }) instead] Load saved pattern |
+| `list` | [DEPRECATED — use pattern_store({ action: "list" }) instead] List saved patterns |
 
 </details>
 
@@ -362,7 +362,7 @@ Then ask Claude:
 
 </details>
 
-<details><summary><strong>Other</strong> (5)</summary>
+<details><summary><strong>Other</strong> (6)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -371,10 +371,11 @@ Then ask Claude:
 | `analyze_pattern_local` | Static analysis (events/cycle, complexity, optional BPM) without browser playback |
 | `query_pattern_events` | Enumerate events the pattern would emit between two cycle indices (max 16 cycles) |
 | `transpile_pattern` | Transpile pattern source via StrudelEngine; returns transpiled code or syntax error |
+| `pattern_store` | Persist patterns to disk and read them back.  |
 
 </details>
 
-_Auto-generated from source. 70 tools registered._
+_Auto-generated from source. 71 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/src/__tests__/unit/PatternStoreConsolidation.test.ts
+++ b/src/__tests__/unit/PatternStoreConsolidation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the pattern_store consolidation (#143).
+ *
+ * Verifies the new pattern_store(action) tool covers save/load/list,
+ * and that the three legacy aliases still forward correctly during the
+ * deprecation window.
+ */
+
+import { execute } from '../../server/tools/storage';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx(): { ctx: ToolContext; store: any; pattern: { current: string } } {
+  const pattern = { current: 's("bd hh")' };
+  const saved = new Map<string, { name: string; content: string; tags: string[]; timestamp: string }>();
+  const store = {
+    save: jest.fn(async (name: string, content: string, tags: string[]) => {
+      saved.set(name, { name, content, tags, timestamp: '2026-05-14T00:00:00Z' });
+    }),
+    load: jest.fn(async (name: string) => saved.get(name) ?? null),
+    list: jest.fn(async (tag?: string) => {
+      const all = Array.from(saved.values());
+      return tag ? all.filter(p => p.tags.includes(tag)) : all;
+    }),
+  };
+
+  const ctx: ToolContext = {
+    controller: {} as any,
+    perfMonitor: {} as any,
+    store: store as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => true,
+    ensureInitialized: async () => {},
+    getController: () => ({}) as any,
+    getCurrentPatternSafe: async () => pattern.current,
+    writePatternSafe: async (p: string) => { pattern.current = p; return 'written'; },
+  };
+  return { ctx, store, pattern };
+}
+
+describe('pattern_store consolidation (#143)', () => {
+  describe('pattern_store(action=save)', () => {
+    it('saves the current pattern with tags', async () => {
+      const { ctx, store } = makeCtx();
+      const result = await execute('pattern_store', { action: 'save', name: 'jam1', tags: ['techno', 'demo'] }, ctx);
+      expect(result).toBe('Pattern saved as "jam1"');
+      expect(store.save).toHaveBeenCalledWith('jam1', 's("bd hh")', ['techno', 'demo']);
+    });
+
+    it('refuses when there is no pattern to save', async () => {
+      const { ctx, pattern } = makeCtx();
+      pattern.current = '';
+      const result = await execute('pattern_store', { action: 'save', name: 'empty' }, ctx);
+      expect(result).toBe('No pattern to save');
+    });
+
+    it('defaults tags to [] when omitted', async () => {
+      const { ctx, store } = makeCtx();
+      await execute('pattern_store', { action: 'save', name: 'untagged' }, ctx);
+      expect(store.save).toHaveBeenCalledWith('untagged', 's("bd hh")', []);
+    });
+  });
+
+  describe('pattern_store(action=load)', () => {
+    it('loads a saved pattern into the current session', async () => {
+      const { ctx, store, pattern } = makeCtx();
+      await store.save('saved1', 'note("c3 e3 g3")', ['melodic']);
+      const result = await execute('pattern_store', { action: 'load', name: 'saved1' }, ctx);
+      expect(result).toBe('Loaded pattern "saved1"');
+      expect(pattern.current).toBe('note("c3 e3 g3")');
+    });
+
+    it('returns a friendly message when name not found', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('pattern_store', { action: 'load', name: 'nope' }, ctx);
+      expect(result).toBe('Pattern "nope" not found');
+    });
+  });
+
+  describe('pattern_store(action=list)', () => {
+    it('returns all saved patterns, formatted', async () => {
+      const { ctx, store } = makeCtx();
+      await store.save('a', 's("bd")', ['techno']);
+      await store.save('b', 's("hh")', ['ambient']);
+      const result = await execute('pattern_store', { action: 'list' }, ctx);
+      expect(typeof result).toBe('string');
+      expect(result as string).toContain('a [techno]');
+      expect(result as string).toContain('b [ambient]');
+    });
+
+    it('filters by tag when given', async () => {
+      const { ctx, store } = makeCtx();
+      await store.save('a', 's("bd")', ['techno']);
+      await store.save('b', 's("hh")', ['ambient']);
+      const result = await execute('pattern_store', { action: 'list', tag: 'techno' }, ctx);
+      expect(result as string).toContain('a');
+      expect(result as string).not.toContain('b');
+    });
+
+    it('returns "No patterns found" when catalog is empty', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('pattern_store', { action: 'list' }, ctx);
+      expect(result).toBe('No patterns found');
+    });
+  });
+
+  describe('invalid action', () => {
+    it('throws on missing action', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('pattern_store', {}, ctx)).rejects.toThrow(/Invalid action/);
+    });
+
+    it('throws on unknown action', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('pattern_store', { action: 'delete' }, ctx)).rejects.toThrow(/Invalid action/);
+    });
+  });
+
+  describe('legacy aliases still forward (deprecation window)', () => {
+    it('save alias produces identical result to pattern_store(action=save)', async () => {
+      const { ctx: ctxA, store: storeA } = makeCtx();
+      const { ctx: ctxB, store: storeB } = makeCtx();
+      const aliasResult = await execute('save', { name: 'x', tags: ['t'] }, ctxA);
+      const newResult = await execute('pattern_store', { action: 'save', name: 'x', tags: ['t'] }, ctxB);
+      expect(aliasResult).toEqual(newResult);
+      expect(storeA.save).toHaveBeenCalledWith('x', 's("bd hh")', ['t']);
+      expect(storeB.save).toHaveBeenCalledWith('x', 's("bd hh")', ['t']);
+    });
+
+    it('load alias forwards', async () => {
+      const { ctx, store } = makeCtx();
+      await store.save('y', 'pat', []);
+      const result = await execute('load', { name: 'y' }, ctx);
+      expect(result).toBe('Loaded pattern "y"');
+    });
+
+    it('list alias forwards', async () => {
+      const { ctx, store } = makeCtx();
+      await store.save('z', 'pat', ['tag1']);
+      const result = await execute('list', { tag: 'tag1' }, ctx);
+      expect(result as string).toContain('z');
+    });
+  });
+});

--- a/src/server/tools/storage.ts
+++ b/src/server/tools/storage.ts
@@ -1,14 +1,15 @@
 /**
- * storage domain — pattern persistence (save, load, list).
+ * storage domain — pattern persistence.
  *
- * Owns (3 tools): save, load, list. Post-consolidation target per the
- * #110 audit: single `pattern_store` tool with `action` enum + params,
- * which also resolves the `list` / `list_sessions` naming collision.
+ * Owns one consolidated tool (`pattern_store`) plus three deprecated
+ * aliases (`save`, `load`, `list`) per the #120 / #143 consolidation.
  *
- * save/load route through the requested session's pattern (#108) but
- * the on-disk catalog is server-wide — saving from session A and
- * loading into session B works fine and is the intended cross-session
- * primitive. `list` is purely on-disk and has no session.
+ * The consolidation also resolves the `list` / `list_sessions` naming
+ * collision from #110 — `pattern_store(action='list')` is unambiguous
+ * versus `session(action='list')` after the #158 session consolidation.
+ *
+ * Aliases forward to `pattern_store` and will be removed in a future
+ * release per the deprecation policy in #120.
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -18,14 +19,39 @@ import { InputValidator } from '../../utils/InputValidator.js';
 const SESSION_ID_PROP = {
   session_id: {
     type: 'string',
-    description: 'Optional session ID (#108). save/load source/target the named session\'s current pattern; the on-disk catalog is shared.',
+    description: 'Optional session ID (#108). Sources/targets the named session\'s current pattern; the on-disk catalog is shared across sessions.',
   },
 };
 
 export const tools: Tool[] = [
   {
+    name: 'pattern_store',
+    description:
+      'Persist patterns to disk and read them back. ' +
+      'Use action=save to write the current session pattern under a name; ' +
+      'action=load to restore a named pattern into the current session; ' +
+      'action=list to enumerate the on-disk catalog (optionally filtered by tag). ' +
+      'Example: pattern_store({ action: "save", name: "my-jam", tags: ["techno"] }). ' +
+      'For session lifecycle (create/destroy/list active sessions) use the session tool — pattern_store deals with on-disk patterns, not runtime sessions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['save', 'load', 'list'],
+          description: 'Which on-disk operation to perform',
+        },
+        name: { type: 'string', description: 'Pattern name (required for save/load)' },
+        tags: { type: 'array', items: { type: 'string' }, description: 'Tags to attach (save only)' },
+        tag: { type: 'string', description: 'Filter by tag (list only)' },
+        ...SESSION_ID_PROP,
+      },
+      required: ['action'],
+    },
+  },
+  {
     name: 'save',
-    description: 'Save pattern with metadata',
+    description: '[DEPRECATED — use pattern_store({ action: "save" }) instead] Save pattern with metadata',
     inputSchema: {
       type: 'object',
       properties: {
@@ -38,7 +64,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'load',
-    description: 'Load saved pattern',
+    description: '[DEPRECATED — use pattern_store({ action: "load" }) instead] Load saved pattern',
     inputSchema: {
       type: 'object',
       properties: {
@@ -50,7 +76,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'list',
-    description: 'List saved patterns',
+    description: '[DEPRECATED — use pattern_store({ action: "list" }) instead] List saved patterns',
     inputSchema: {
       type: 'object',
       properties: {
@@ -62,38 +88,58 @@ export const tools: Tool[] = [
 
 export const toolNames = new Set(tools.map(t => t.name));
 
+async function doSave(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.name, 'name', 255, false);
+  const toSave = await ctx.getCurrentPatternSafe(sid);
+  if (!toSave) {
+    return 'No pattern to save';
+  }
+  await ctx.store.save(args.name, toSave, args.tags || []);
+  return `Pattern saved as "${args.name}"`;
+}
+
+async function doLoad(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.name, 'name', 255, false);
+  const saved = await ctx.store.load(args.name);
+  if (saved) {
+    await ctx.writePatternSafe(saved.content, sid);
+    return `Loaded pattern "${args.name}"`;
+  }
+  return `Pattern "${args.name}" not found`;
+}
+
+async function doList(args: any, ctx: ToolContext): Promise<unknown> {
+  if (args?.tag) {
+    InputValidator.validateStringLength(args.tag, 'tag', 100, false);
+  }
+  const patterns = await ctx.store.list(args?.tag);
+  return patterns.map(p =>
+    `• ${p.name} [${p.tags.join(', ')}] - ${p.timestamp}`
+  ).join('\n') || 'No patterns found';
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
   switch (name) {
-    case 'save': {
-      InputValidator.validateStringLength(args.name, 'name', 255, false);
-      const toSave = await ctx.getCurrentPatternSafe(sid);
-      if (!toSave) {
-        return 'No pattern to save';
+    case 'pattern_store': {
+      const action = args?.action;
+      if (!action || !['save', 'load', 'list'].includes(action)) {
+        throw new Error(`Invalid action: ${action}. Must be one of: save, load, list`);
       }
-      await ctx.store.save(args.name, toSave, args.tags || []);
-      return `Pattern saved as "${args.name}"`;
+      switch (action) {
+        case 'save': return await doSave(args, ctx, sid);
+        case 'load': return await doLoad(args, ctx, sid);
+        case 'list': return await doList(args, ctx);
+      }
+      // Unreachable due to enum check above, but TypeScript wants it.
+      return undefined;
     }
 
-    case 'load': {
-      InputValidator.validateStringLength(args.name, 'name', 255, false);
-      const saved = await ctx.store.load(args.name);
-      if (saved) {
-        await ctx.writePatternSafe(saved.content, sid);
-        return `Loaded pattern "${args.name}"`;
-      }
-      return `Pattern "${args.name}" not found`;
-    }
-
-    case 'list': {
-      if (args?.tag) {
-        InputValidator.validateStringLength(args.tag, 'tag', 100, false);
-      }
-      const patterns = await ctx.store.list(args?.tag);
-      return patterns.map(p =>
-        `• ${p.name} [${p.tags.join(', ')}] - ${p.timestamp}`
-      ).join('\n') || 'No patterns found';
-    }
+    // Aliases — forward to consolidated handler. Kept for ≥1 release per
+    // #120 migration rules; removed afterwards.
+    case 'save': return await doSave(args, ctx, sid);
+    case 'load': return await doLoad(args, ctx, sid);
+    case 'list': return await doList(args, ctx);
 
     default:
       throw new Error(`storage module does not handle tool: ${name}`);


### PR DESCRIPTION
First installment of #120 (tool consolidation epic). Closes #143.

## Summary

Adds a single \`pattern_store(action)\` tool covering the three legacy verbs. \`save\`/\`load\`/\`list\` remain as deprecated aliases that forward to the new handler — they'll be removed in a future release per the #120 migration policy.

**Also resolves the \`list\` / \`list_sessions\` naming collision** flagged in the #110 audit: \`pattern_store(action='list')\` is now the canonical read of the on-disk catalog, distinct from the future \`session(action='list')\` (Phase 4 / #158).

## New tool shape

\`\`\`
pattern_store({ action: 'save', name, tags?, session_id? })
pattern_store({ action: 'load', name, session_id? })
pattern_store({ action: 'list', tag? })
\`\`\`

Description carries the #127 finding #2 acceptance (example, boundary, disambiguation).

## Tool surface

| | Before | After (during deprecation) | After alias removal |
|---|---|---|---|
| Tools | 70 | 71 | 68 |

Net consolidation: -2 tools once the aliases are removed (next major release).

## Test plan

- [x] 13 new cases in \`src/__tests__/unit/PatternStoreConsolidation.test.ts\` — every action, error paths, alias-forwarding equivalence
- [x] All save/load/list paths in existing tests continue to pass (no schema surprise)
- [x] Full suite: 1592 pass, 20 skipped, 0 fail (was 1579 → +13)
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean (0 errors, 129 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

## Out of scope

- Removing the deprecated aliases — separate follow-up PR after at least one release cycle, per the #120 migration policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)