### PR TITLE
feat(#144): consolidate diagnostics tools → diagnostics(level)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `status` | Get current browser and playback status (quick state check) |
+| `status` | [DEPRECATED — use diagnostics({ level: "status" }) instead] Get current browser and playback status (quick state check) |
 | `clear` | Clear the editor |
 | `play` | Start playing pattern |
 | `pause` | Pause playback |
@@ -355,10 +355,10 @@ Then ask Claude:
 | Tool | Description |
 |------|-------------|
 | `show_browser` | Bring browser window to foreground for visual feedback |
-| `performance_report` | Get performance metrics and bottlenecks |
-| `memory_usage` | Get current memory usage statistics |
-| `diagnostics` | Get detailed browser diagnostics including cache, errors, and performance |
-| `show_errors` | Display captured console errors and warnings from Strudel |
+| `diagnostics` | Inspect server and browser state.  |
+| `show_errors` | [DEPRECATED — use diagnostics({ level: "errors" }) instead] Display captured console errors and warnings from Strudel |
+| `performance_report` | [DEPRECATED — use diagnostics({ level: "perf" }) instead] Get performance metrics and bottlenecks |
+| `memory_usage` | [DEPRECATED — use diagnostics({ level: "memory" }) instead] Get current memory usage statistics |
 
 </details>
 

--- a/src/__tests__/unit/DiagnosticsConsolidation.test.ts
+++ b/src/__tests__/unit/DiagnosticsConsolidation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the diagnostics consolidation (#144).
+ *
+ * Verifies the diagnostics(level) tool covers status/full/perf/memory/
+ * errors, defaults to 'full' for backwards compat, and that the four
+ * legacy aliases still forward correctly during the deprecation window.
+ */
+
+import { execute } from '../../server/tools/diagnostics';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx(initialized = true) {
+  const controller = {
+    getStatus: jest.fn(() => ({ playing: true, patternLength: 42 })),
+    getDiagnostics: jest.fn(async () => ({ cache: 'fresh', errors: 0 })),
+    getConsoleErrors: jest.fn(() => ['err1', 'err2']),
+    getConsoleWarnings: jest.fn(() => ['warn1']),
+    takeScreenshot: jest.fn(async (filename?: string) => `saved to ${filename ?? 'default.png'}`),
+  };
+  const perfMonitor = {
+    getReport: jest.fn(() => 'perf report'),
+    getBottlenecks: jest.fn(() => [{ name: 'slow', ms: 200 }]),
+    getMemoryUsage: jest.fn(() => ({ rss: 100000 })),
+  };
+  const ctx: ToolContext = {
+    controller: controller as any,
+    perfMonitor: perfMonitor as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => initialized,
+    ensureInitialized: async () => {},
+    getController: () => controller as any,
+    getCurrentPatternSafe: async () => 'pattern',
+    writePatternSafe: async () => 'written',
+  };
+  return { ctx, controller, perfMonitor };
+}
+
+describe('diagnostics consolidation (#144)', () => {
+  describe('diagnostics(level)', () => {
+    it('level=status returns quick status (no browser call beyond getStatus)', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = await execute('diagnostics', { level: 'status' }, ctx);
+      expect(result).toEqual({ playing: true, patternLength: 42 });
+      expect(controller.getStatus).toHaveBeenCalledTimes(1);
+      expect(controller.getDiagnostics).not.toHaveBeenCalled();
+    });
+
+    it('level=full returns detailed browser diagnostics', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = await execute('diagnostics', { level: 'full' }, ctx);
+      expect(result).toEqual({ cache: 'fresh', errors: 0 });
+      expect(controller.getDiagnostics).toHaveBeenCalledTimes(1);
+    });
+
+    it('level=full when browser not initialized returns gentle stub', async () => {
+      const { ctx } = makeCtx(false);
+      const result = await execute('diagnostics', { level: 'full' }, ctx);
+      expect(result).toMatchObject({ initialized: false });
+    });
+
+    it('level=perf returns timing report', async () => {
+      const { ctx, perfMonitor } = makeCtx();
+      const result = await execute('diagnostics', { level: 'perf' }, ctx);
+      expect(typeof result).toBe('string');
+      expect(result as string).toContain('perf report');
+      expect(result as string).toContain('Bottlenecks');
+      expect(perfMonitor.getReport).toHaveBeenCalled();
+    });
+
+    it('level=memory returns memory snapshot', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('diagnostics', { level: 'memory' }, ctx);
+      expect(result as string).toContain('rss');
+    });
+
+    it('level=memory gracefully reports when unavailable', async () => {
+      const { ctx, perfMonitor } = makeCtx();
+      (perfMonitor.getMemoryUsage as jest.Mock).mockReturnValueOnce(null);
+      const result = await execute('diagnostics', { level: 'memory' }, ctx);
+      expect(result).toBe('Memory usage not available');
+    });
+
+    it('level=errors lists console errors and warnings', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('diagnostics', { level: 'errors' }, ctx);
+      const text = result as string;
+      expect(text).toContain('Errors (2)');
+      expect(text).toContain('err1');
+      expect(text).toContain('Warnings (1)');
+      expect(text).toContain('warn1');
+    });
+
+    it('level=errors returns clean message when nothing captured', async () => {
+      const { ctx, controller } = makeCtx();
+      (controller.getConsoleErrors as jest.Mock).mockReturnValueOnce([]);
+      (controller.getConsoleWarnings as jest.Mock).mockReturnValueOnce([]);
+      const result = await execute('diagnostics', { level: 'errors' }, ctx);
+      expect(result).toBe('No errors or warnings captured.');
+    });
+
+    it('default level is "full" (no schema surprise)', async () => {
+      const { ctx, controller } = makeCtx();
+      const noLevel = await execute('diagnostics', {}, ctx);
+      const fullLevel = await execute('diagnostics', { level: 'full' }, ctx);
+      expect(noLevel).toEqual(fullLevel);
+      expect(controller.getDiagnostics).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws on invalid level', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('diagnostics', { level: 'bogus' }, ctx)).rejects.toThrow(/Invalid level/);
+    });
+  });
+
+  describe('legacy aliases forward (deprecation window)', () => {
+    it('status alias matches diagnostics(level=status)', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('status', {}, ctx);
+      const direct = await execute('diagnostics', { level: 'status' }, ctx);
+      expect(alias).toEqual(direct);
+    });
+
+    it('show_errors alias matches diagnostics(level=errors)', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('show_errors', {}, ctx);
+      const direct = await execute('diagnostics', { level: 'errors' }, ctx);
+      expect(alias).toEqual(direct);
+    });
+
+    it('performance_report alias matches diagnostics(level=perf)', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('performance_report', {}, ctx);
+      const direct = await execute('diagnostics', { level: 'perf' }, ctx);
+      expect(alias).toEqual(direct);
+    });
+
+    it('memory_usage alias matches diagnostics(level=memory)', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('memory_usage', {}, ctx);
+      const direct = await execute('diagnostics', { level: 'memory' }, ctx);
+      expect(alias).toEqual(direct);
+    });
+  });
+
+  describe('screenshot stays distinct (Phase 3 / #156 absorbs it elsewhere)', () => {
+    it('screenshot routes via the controller', async () => {
+      const { ctx, controller } = makeCtx();
+      await execute('screenshot', { filename: 'shot.png' }, ctx);
+      expect(controller.takeScreenshot).toHaveBeenCalledWith('shot.png');
+    });
+
+    it('screenshot refuses when not initialized', async () => {
+      const { ctx } = makeCtx(false);
+      const result = await execute('screenshot', {}, ctx);
+      expect(result).toContain('not initialized');
+    });
+  });
+});

--- a/src/server/tools/diagnostics.ts
+++ b/src/server/tools/diagnostics.ts
@@ -1,12 +1,18 @@
 /**
- * diagnostics domain — performance, memory, status, errors, screenshots.
+ * diagnostics domain — observability tools (browser status, errors,
+ * server metrics).
  *
- * Owns (6 tools today): performance_report, memory_usage, screenshot,
- * status, diagnostics, show_errors.
+ * Owns one consolidated tool (`diagnostics(level)`) plus four deprecated
+ * aliases (`status`, `show_errors`, `performance_report`, `memory_usage`)
+ * per #120 / #144.
  *
- * Post-consolidation target (per #110 audit): one `diagnostics` tool with
- * a `level` enum. For now we keep the individual verbs and only move them
- * out of server.ts; consolidation happens later under #120.
+ * The `<15ms` SLA on `level='status'` is preserved — that branch only
+ * reads from the controller's cache, not the browser. Other levels can
+ * touch the browser (`level='full'`) or just inspect server state
+ * (`perf`, `memory`).
+ *
+ * `screenshot` stays separate; it folds into `browser_window` per
+ * Phase 3 (#156).
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -15,21 +21,53 @@ import type { ToolContext, ToolModule } from './types.js';
 const SESSION_ID_PROP = {
   session_id: {
     type: 'string',
-    description: 'Optional session ID (#108). Omit to use default session.',
+    description: 'Optional session ID (#108). Applies to level=status, full, errors. Ignored for perf/memory (server-wide metrics).',
   },
 };
 
 export const tools: Tool[] = [
   {
-    // Server-wide metric; session_id not applicable.
+    name: 'diagnostics',
+    description:
+      'Inspect server and browser state. ' +
+      'level=status returns a quick state snapshot (cache read, <15ms SLA). ' +
+      'level=full returns detailed browser diagnostics including caches, errors, and performance. ' +
+      'level=perf returns server-side timing metrics + top bottlenecks. ' +
+      'level=memory returns process memory usage. ' +
+      'level=errors returns captured console errors and warnings from Strudel. ' +
+      'Default level=full preserves the pre-consolidation behaviour. ' +
+      'Example: diagnostics({ level: "status" }) — millisecond-cheap. ' +
+      'For screenshots use browser_window (Phase 3 / #156); for tool listings use the strudel://docs/tools resource.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        level: {
+          type: 'string',
+          enum: ['status', 'full', 'perf', 'memory', 'errors'],
+          description: 'Which diagnostic surface to read (default: full)',
+        },
+        ...SESSION_ID_PROP,
+      },
+    },
+  },
+  {
+    name: 'status',
+    description: '[DEPRECATED — use diagnostics({ level: "status" }) instead] Get current browser and playback status (quick state check)',
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
+  },
+  {
+    name: 'show_errors',
+    description: '[DEPRECATED — use diagnostics({ level: "errors" }) instead] Display captured console errors and warnings from Strudel',
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
+  },
+  {
     name: 'performance_report',
-    description: 'Get performance metrics and bottlenecks',
+    description: '[DEPRECATED — use diagnostics({ level: "perf" }) instead] Get performance metrics and bottlenecks',
     inputSchema: { type: 'object', properties: {} },
   },
   {
-    // Server-wide; session_id not applicable.
     name: 'memory_usage',
-    description: 'Get current memory usage statistics',
+    description: '[DEPRECATED — use diagnostics({ level: "memory" }) instead] Get current memory usage statistics',
     inputSchema: { type: 'object', properties: {} },
   },
   {
@@ -43,76 +81,82 @@ export const tools: Tool[] = [
       },
     },
   },
-  {
-    name: 'status',
-    description: 'Get current browser and playback status (quick state check)',
-    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
-  },
-  {
-    name: 'diagnostics',
-    description: 'Get detailed browser diagnostics including cache, errors, and performance',
-    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
-  },
-  {
-    name: 'show_errors',
-    description: 'Display captured console errors and warnings from Strudel',
-    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
-  },
 ];
 
 export const toolNames = new Set(tools.map(t => t.name));
 
+function getPerformanceReport(ctx: ToolContext): string {
+  const report = ctx.perfMonitor.getReport();
+  const bottlenecks = ctx.perfMonitor.getBottlenecks(5);
+  return `${report}\n\nTop 5 Bottlenecks:\n${JSON.stringify(bottlenecks, null, 2)}`;
+}
+
+function getMemoryUsage(ctx: ToolContext): string {
+  const memory = ctx.perfMonitor.getMemoryUsage();
+  return memory ? JSON.stringify(memory, null, 2) : 'Memory usage not available';
+}
+
+function getStatus(ctx: ToolContext, sid?: string): unknown {
+  return ctx.getController(sid).getStatus();
+}
+
+async function getFullDiagnostics(ctx: ToolContext, sid?: string): Promise<unknown> {
+  if (!sid && !ctx.isInitialized()) {
+    return {
+      initialized: false,
+      message: 'Browser not initialized. Run init first for full diagnostics.',
+    };
+  }
+  return await ctx.getController(sid).getDiagnostics();
+}
+
+function getErrors(ctx: ToolContext, sid?: string): string {
+  const controller = ctx.getController(sid);
+  const errors = controller.getConsoleErrors();
+  const warnings = controller.getConsoleWarnings();
+
+  if (errors.length === 0 && warnings.length === 0) {
+    return 'No errors or warnings captured.';
+  }
+
+  let result = '';
+  if (errors.length > 0) {
+    result += `❌ Errors (${errors.length}):\n${errors.map(e => `  • ${e}`).join('\n')}\n`;
+  }
+  if (warnings.length > 0) {
+    result += `⚠️ Warnings (${warnings.length}):\n${warnings.map(w => `  • ${w}`).join('\n')}`;
+  }
+  return result.trim();
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
   switch (name) {
-    case 'performance_report': {
-      const report = ctx.perfMonitor.getReport();
-      const bottlenecks = ctx.perfMonitor.getBottlenecks(5);
-      return `${report}\n\nTop 5 Bottlenecks:\n${JSON.stringify(bottlenecks, null, 2)}`;
+    case 'diagnostics': {
+      const level = args?.level ?? 'full';
+      switch (level) {
+        case 'status':  return getStatus(ctx, sid);
+        case 'full':    return await getFullDiagnostics(ctx, sid);
+        case 'perf':    return getPerformanceReport(ctx);
+        case 'memory':  return getMemoryUsage(ctx);
+        case 'errors':  return getErrors(ctx, sid);
+        default:
+          throw new Error(`Invalid level: ${level}. Must be one of: status, full, perf, memory, errors`);
+      }
     }
 
-    case 'memory_usage': {
-      const memory = ctx.perfMonitor.getMemoryUsage();
-      return memory ? JSON.stringify(memory, null, 2) : 'Memory usage not available';
-    }
+    // Deprecated aliases — forward to consolidated handler. Kept for ≥1
+    // release per #120 migration policy.
+    case 'status':              return getStatus(ctx, sid);
+    case 'show_errors':         return getErrors(ctx, sid);
+    case 'performance_report':  return getPerformanceReport(ctx);
+    case 'memory_usage':        return getMemoryUsage(ctx);
 
     case 'screenshot': {
       if (!sid && !ctx.isInitialized()) {
         return 'Browser not initialized. Run init first.';
       }
       return await ctx.getController(sid).takeScreenshot(args?.filename);
-    }
-
-    case 'status':
-      return ctx.getController(sid).getStatus();
-
-    case 'diagnostics': {
-      if (!sid && !ctx.isInitialized()) {
-        return {
-          initialized: false,
-          message: 'Browser not initialized. Run init first for full diagnostics.',
-        };
-      }
-      return await ctx.getController(sid).getDiagnostics();
-    }
-
-    case 'show_errors': {
-      const controller = ctx.getController(sid);
-      const errors = controller.getConsoleErrors();
-      const warnings = controller.getConsoleWarnings();
-
-      if (errors.length === 0 && warnings.length === 0) {
-        return 'No errors or warnings captured.';
-      }
-
-      let result = '';
-      if (errors.length > 0) {
-        result += `❌ Errors (${errors.length}):\n${errors.map(e => `  • ${e}`).join('\n')}\n`;
-      }
-      if (warnings.length > 0) {
-        result += `⚠️ Warnings (${warnings.length}):\n${warnings.map(w => `  • ${w}`).join('\n')}`;
-      }
-      return result.trim();
     }
 
     default:


### PR DESCRIPTION
Second installment of #120. Closes #144.

## Summary

The \`diagnostics\` tool now takes a \`level\` enum covering five surfaces. The four legacy verbs (\`status\`, \`show_errors\`, \`performance_report\`, \`memory_usage\`) become deprecated aliases that forward to the new handler.

| Level | Surface | Old equivalent |
|---|---|---|
| \`status\` | Quick state snapshot (cache read, <15ms SLA preserved) | \`status\` |
| \`full\` | Detailed browser diagnostics (**default**) | \`diagnostics\` |
| \`perf\` | Server-side timing + top bottlenecks | \`performance_report\` |
| \`memory\` | Process memory usage | \`memory_usage\` |
| \`errors\` | Captured console errors/warnings | \`show_errors\` |

Default \`level='full'\` preserves pre-consolidation behaviour — no schema surprise per #120 migration rules.

\`screenshot\` stays distinct; it folds into \`browser_window\` per Phase 3 (#156).

## Test plan

- [x] 16 new cases in \`DiagnosticsConsolidation.test.ts\`: every level, default behaviour, error paths, alias-forwarding equivalence, not-initialized handling for full + screenshot
- [x] \`tsc --noEmit\` clean
- [x] Full suite: 1595 pass, 20 skipped, 0 fail
- [x] \`npm run lint\` clean (0 errors, 126 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

Tool count unchanged at 70 during deprecation; will be -4 once aliases are removed (follow-up PR after ≥1 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)