### PR TITLE
feat(#145): consolidate history tools → history(action)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-71-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-72-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -197,7 +197,7 @@ Then ask Claude:
 
 <!-- TOOLS:START -->
 
-**71 tools** across 15 categories:
+**72 tools** across 15 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -246,10 +246,10 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `undo` | Undo last action |
-| `redo` | Redo action |
-| `list_history` | List recent pattern history with timestamps and previews |
-| `restore_history` | Restore a previous pattern from history by ID |
+| `undo` | [DEPRECATED — use history({ action: "undo" }) instead] Undo last action |
+| `redo` | [DEPRECATED — use history({ action: "redo" }) instead] Redo action |
+| `list_history` | [DEPRECATED — use history({ action: "list" }) instead] List recent pattern history with timestamps and previews |
+| `restore_history` | [DEPRECATED — use history({ action: "restore" }) instead] Restore a previous pattern from history by ID |
 
 </details>
 
@@ -316,7 +316,7 @@ Then ask Claude:
 | `detect_tempo` | BPM detection |
 | `detect_key` | Key detection |
 | `validate_pattern_runtime` | Validate pattern with runtime error checking (monitors Strudel console for errors) |
-| `compare_patterns` | Compare two patterns from history showing differences |
+| `compare_patterns` | [DEPRECATED — use history({ action: "compare" }) instead] Compare two patterns from history showing differences |
 
 </details>
 
@@ -362,7 +362,7 @@ Then ask Claude:
 
 </details>
 
-<details><summary><strong>Other</strong> (6)</summary>
+<details><summary><strong>Other</strong> (7)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -371,11 +371,12 @@ Then ask Claude:
 | `analyze_pattern_local` | Static analysis (events/cycle, complexity, optional BPM) without browser playback |
 | `query_pattern_events` | Enumerate events the pattern would emit between two cycle indices (max 16 cycles) |
 | `transpile_pattern` | Transpile pattern source via StrudelEngine; returns transpiled code or syntax error |
+| `history` | Navigate or inspect the pattern edit history.  |
 | `pattern_store` | Persist patterns to disk and read them back.  |
 
 </details>
 
-_Auto-generated from source. 71 tools registered._
+_Auto-generated from source. 72 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/src/__tests__/unit/HistoryConsolidation.test.ts
+++ b/src/__tests__/unit/HistoryConsolidation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the history consolidation (#145).
+ *
+ * Verifies history(action) covers undo/redo/list/restore/compare and
+ * that the five legacy aliases still forward correctly during the
+ * deprecation window.
+ */
+
+import { execute } from '../../server/tools/history';
+import type { HistoryEntry, ToolContext } from '../../server/tools/types';
+
+function makeCtx(initialized = true) {
+  let currentPattern = 's("bd")';
+  const controller = {
+    getCurrentPattern: jest.fn(async () => currentPattern),
+    writePattern: jest.fn(async (p: string) => { currentPattern = p; return 'written'; }),
+  };
+  const history = {
+    undoStack: [] as string[],
+    redoStack: [] as string[],
+    historyStack: [] as HistoryEntry[],
+    maxHistory: 100,
+  };
+  const ctx: ToolContext = {
+    controller: controller as any,
+    perfMonitor: {} as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history,
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => initialized,
+    ensureInitialized: async () => {},
+    getController: () => controller as any,
+    getCurrentPatternSafe: async () => currentPattern,
+    writePatternSafe: async (p: string) => { currentPattern = p; return 'written'; },
+  };
+  return { ctx, controller, history, currentPattern: () => currentPattern };
+}
+
+function entry(id: number, pattern: string, action = 'write'): HistoryEntry {
+  return { id, pattern, action, timestamp: new Date() };
+}
+
+describe('history consolidation (#145)', () => {
+  describe('history(action=undo)', () => {
+    it('pops the undo stack and restores the previous pattern', async () => {
+      const { ctx, history, controller } = makeCtx();
+      history.undoStack.push('previous');
+      const result = await execute('history', { action: 'undo' }, ctx);
+      expect(result).toBe('Undone');
+      expect(controller.writePattern).toHaveBeenCalledWith('previous');
+      expect(history.redoStack).toContain('s("bd")');
+    });
+
+    it('returns "Nothing to undo" when stack empty', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('history', { action: 'undo' }, ctx);
+      expect(result).toBe('Nothing to undo');
+    });
+
+    it('returns init error when default session not up', async () => {
+      const { ctx, history } = makeCtx(false);
+      history.undoStack.push('previous');
+      const result = await execute('history', { action: 'undo' }, ctx);
+      expect(result).toContain('not initialized');
+    });
+  });
+
+  describe('history(action=redo)', () => {
+    it('pops the redo stack and re-applies', async () => {
+      const { ctx, history, controller } = makeCtx();
+      history.redoStack.push('next');
+      const result = await execute('history', { action: 'redo' }, ctx);
+      expect(result).toBe('Redone');
+      expect(controller.writePattern).toHaveBeenCalledWith('next');
+    });
+
+    it('returns "Nothing to redo" when stack empty', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('history', { action: 'redo' }, ctx);
+      expect(result).toBe('Nothing to redo');
+    });
+  });
+
+  describe('history(action=list)', () => {
+    it('returns formatted entries with previews', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(1, 's("bd")'));
+      history.historyStack.push(entry(2, 'note("c3")'));
+      const result = (await execute('history', { action: 'list' }, ctx)) as any;
+      expect(result.count).toBe(2);
+      expect(result.entries[0].id).toBe(2); // reverse order
+      expect(result.entries[0].preview).toContain('note');
+    });
+
+    it('respects limit', async () => {
+      const { ctx, history } = makeCtx();
+      for (let i = 1; i <= 25; i++) history.historyStack.push(entry(i, `p${i}`));
+      const result = (await execute('history', { action: 'list', limit: 5 }, ctx)) as any;
+      expect(result.showing).toBe(5);
+    });
+
+    it('returns clean message when empty', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('history', { action: 'list' }, ctx);
+      expect(result).toContain('No pattern history yet');
+    });
+  });
+
+  describe('history(action=restore)', () => {
+    it('restores an entry by id, pushing current to undo', async () => {
+      const { ctx, history, controller } = makeCtx();
+      history.historyStack.push(entry(42, 'old pattern'));
+      const result = await execute('history', { action: 'restore', id: 42 }, ctx);
+      expect(result).toContain('#42');
+      expect(controller.writePattern).toHaveBeenCalledWith('old pattern');
+      expect(history.undoStack).toContain('s("bd")');
+    });
+
+    it('reports missing id', async () => {
+      const { ctx } = makeCtx();
+      const result = await execute('history', { action: 'restore', id: 999 }, ctx);
+      expect(result).toContain('#999 not found');
+    });
+  });
+
+  describe('history(action=compare)', () => {
+    it('compares two entries by id', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(1, 'aaa'));
+      history.historyStack.push(entry(2, 'bbb'));
+      const result = (await execute('history', { action: 'compare', id1: 1, id2: 2 }, ctx)) as any;
+      expect(result.pattern1.id).toBe(1);
+      expect(result.pattern2.id).toBe('#2');
+      expect(result.summary).toBeDefined();
+    });
+
+    it('compares an entry vs current when id2 omitted', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(1, 'aaa'));
+      const result = (await execute('history', { action: 'compare', id1: 1 }, ctx)) as any;
+      expect(result.pattern2.id).toBe('current');
+    });
+  });
+
+  describe('invalid action', () => {
+    it('throws on missing action', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('history', {}, ctx)).rejects.toThrow(/Invalid action/);
+    });
+
+    it('throws on unknown action', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('history', { action: 'clear' }, ctx)).rejects.toThrow(/Invalid action/);
+    });
+  });
+
+  describe('legacy aliases forward (deprecation window)', () => {
+    it('undo alias matches history(action=undo)', async () => {
+      const { ctx, history } = makeCtx();
+      history.undoStack.push('prev');
+      const aliasResult = await execute('undo', {}, ctx);
+      expect(aliasResult).toBe('Undone');
+    });
+
+    it('list_history alias matches history(action=list)', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(1, 'x'));
+      const alias = (await execute('list_history', {}, ctx)) as any;
+      const direct = (await execute('history', { action: 'list' }, ctx)) as any;
+      expect(alias.count).toBe(direct.count);
+    });
+
+    it('restore_history alias matches history(action=restore)', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(5, 'restored'));
+      const aliasResult = await execute('restore_history', { id: 5 }, ctx);
+      expect(aliasResult).toContain('#5');
+    });
+
+    it('compare_patterns alias matches history(action=compare)', async () => {
+      const { ctx, history } = makeCtx();
+      history.historyStack.push(entry(1, 'a'));
+      history.historyStack.push(entry(2, 'b'));
+      const alias = (await execute('compare_patterns', { id1: 1, id2: 2 }, ctx)) as any;
+      const direct = (await execute('history', { action: 'compare', id1: 1, id2: 2 }, ctx)) as any;
+      expect(alias.summary).toEqual(direct.summary);
+    });
+  });
+});

--- a/src/server/tools/history.ts
+++ b/src/server/tools/history.ts
@@ -24,18 +24,46 @@ const SESSION_ID_PROP = {
 
 export const tools: Tool[] = [
   {
+    name: 'history',
+    description:
+      'Navigate or inspect the pattern edit history. ' +
+      'action=undo reverts the last edit on the targeted session. ' +
+      'action=redo replays a previously-undone edit. ' +
+      'action=list returns recent entries with timestamps and previews (limit defaults to 10). ' +
+      'action=restore jumps the editor to a specific entry by id (current pattern goes on the undo stack). ' +
+      'action=compare diffs two entries by id (or one entry vs current pattern). ' +
+      'Example: history({ action: "list", limit: 5 }) — recent edits, newest first. ' +
+      'For on-disk saved patterns use pattern_store — history deals with the in-memory edit timeline of the current session.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['undo', 'redo', 'list', 'restore', 'compare'],
+          description: 'Which history operation to perform',
+        },
+        limit: { type: 'number', description: 'Maximum entries (action=list, default 10)' },
+        id: { type: 'number', description: 'History entry ID (action=restore)' },
+        id1: { type: 'number', description: 'First entry ID (action=compare)' },
+        id2: { type: 'number', description: 'Second entry ID (action=compare, default: current pattern)' },
+        ...SESSION_ID_PROP,
+      },
+      required: ['action'],
+    },
+  },
+  {
     name: 'undo',
-    description: 'Undo last action',
+    description: '[DEPRECATED — use history({ action: "undo" }) instead] Undo last action',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'redo',
-    description: 'Redo action',
+    description: '[DEPRECATED — use history({ action: "redo" }) instead] Redo action',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'list_history',
-    description: 'List recent pattern history with timestamps and previews',
+    description: '[DEPRECATED — use history({ action: "list" }) instead] List recent pattern history with timestamps and previews',
     inputSchema: {
       type: 'object',
       properties: {
@@ -45,7 +73,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'restore_history',
-    description: 'Restore a previous pattern from history by ID',
+    description: '[DEPRECATED — use history({ action: "restore" }) instead] Restore a previous pattern from history by ID',
     inputSchema: {
       type: 'object',
       properties: {
@@ -57,7 +85,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'compare_patterns',
-    description: 'Compare two patterns from history showing differences',
+    description: '[DEPRECATED — use history({ action: "compare" }) instead] Compare two patterns from history showing differences',
     inputSchema: {
       type: 'object',
       properties: {
@@ -118,98 +146,122 @@ function summarizeDiff(a: string, b: string): {
   return { linesAdded: added, linesRemoved: removed, linesChanged: changed, charsDiff: b.length - a.length };
 }
 
+async function doUndo(ctx: ToolContext, sid?: string): Promise<unknown> {
+  const { undoStack, redoStack, maxHistory } = ctx.history;
+  if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+  if (undoStack.length === 0) return 'Nothing to undo';
+  const controller = ctx.getController(sid);
+
+  const current = await controller.getCurrentPattern();
+  redoStack.push(current);
+  if (redoStack.length > maxHistory) redoStack.shift();
+
+  const previous = undoStack.pop()!;
+  await controller.writePattern(previous);
+  return 'Undone';
+}
+
+async function doRedo(ctx: ToolContext, sid?: string): Promise<unknown> {
+  const { undoStack, redoStack, maxHistory } = ctx.history;
+  if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+  if (redoStack.length === 0) return 'Nothing to redo';
+  const controller = ctx.getController(sid);
+
+  const current = await controller.getCurrentPattern();
+  undoStack.push(current);
+  if (undoStack.length > maxHistory) undoStack.shift();
+
+  const next = redoStack.pop()!;
+  await controller.writePattern(next);
+  return 'Redone';
+}
+
+function doList(args: any, ctx: ToolContext): unknown {
+  const { historyStack } = ctx.history;
+  if (historyStack.length === 0) {
+    return 'No pattern history yet. Make some edits to build history.';
+  }
+  const limit = args?.limit || 10;
+  const recent = historyStack.slice(-limit).reverse();
+  return {
+    count: historyStack.length,
+    showing: recent.length,
+    entries: recent.map(e => ({
+      id: e.id,
+      preview: e.pattern.substring(0, 60) + (e.pattern.length > 60 ? '...' : ''),
+      chars: e.pattern.length,
+      action: e.action,
+      timestamp: formatTimeAgo(e.timestamp),
+    })),
+  };
+}
+
+async function doRestore(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  const { undoStack, historyStack, maxHistory } = ctx.history;
+  if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
+  const controller = ctx.getController(sid);
+
+  const entry = historyStack.find(e => e.id === args.id);
+  if (!entry) {
+    return `History entry #${args.id} not found. Use history({ action: "list" }) to see available entries.`;
+  }
+
+  const current = await controller.getCurrentPattern();
+  undoStack.push(current);
+  if (undoStack.length > maxHistory) undoStack.shift();
+
+  await controller.writePattern(entry.pattern);
+  return `Restored pattern from history #${args.id} (${formatTimeAgo(entry.timestamp)})`;
+}
+
+async function doCompare(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  const { historyStack } = ctx.history;
+  const first = historyStack.find(e => e.id === args.id1);
+  if (!first) return `History entry #${args.id1} not found.`;
+
+  let second: string;
+  let label: string;
+  if (args.id2) {
+    const b = historyStack.find(e => e.id === args.id2);
+    if (!b) return `History entry #${args.id2} not found.`;
+    second = b.pattern;
+    label = `#${args.id2}`;
+  } else {
+    second = await ctx.getCurrentPatternSafe(sid);
+    label = 'current';
+  }
+
+  return {
+    pattern1: { id: args.id1, chars: first.pattern.length },
+    pattern2: { id: label, chars: second.length },
+    diff: generateDiff(first.pattern, second),
+    summary: summarizeDiff(first.pattern, second),
+  };
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
-  const { undoStack, redoStack, historyStack, maxHistory } = ctx.history;
   const sid: string | undefined = args?.session_id;
 
   switch (name) {
-    case 'undo': {
-      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
-      if (undoStack.length === 0) return 'Nothing to undo';
-      const controller = ctx.getController(sid);
-
-      const current = await controller.getCurrentPattern();
-      redoStack.push(current);
-      if (redoStack.length > maxHistory) redoStack.shift();
-
-      const previous = undoStack.pop()!;
-      await controller.writePattern(previous);
-      return 'Undone';
-    }
-
-    case 'redo': {
-      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
-      if (redoStack.length === 0) return 'Nothing to redo';
-      const controller = ctx.getController(sid);
-
-      const current = await controller.getCurrentPattern();
-      undoStack.push(current);
-      if (undoStack.length > maxHistory) undoStack.shift();
-
-      const next = redoStack.pop()!;
-      await controller.writePattern(next);
-      return 'Redone';
-    }
-
-    case 'list_history': {
-      if (historyStack.length === 0) {
-        return 'No pattern history yet. Make some edits to build history.';
+    case 'history': {
+      const action = args?.action;
+      switch (action) {
+        case 'undo':    return await doUndo(ctx, sid);
+        case 'redo':    return await doRedo(ctx, sid);
+        case 'list':    return doList(args, ctx);
+        case 'restore': return await doRestore(args, ctx, sid);
+        case 'compare': return await doCompare(args, ctx, sid);
+        default:
+          throw new Error(`Invalid action: ${action}. Must be one of: undo, redo, list, restore, compare`);
       }
-      const limit = args?.limit || 10;
-      const recent = historyStack.slice(-limit).reverse();
-      return {
-        count: historyStack.length,
-        showing: recent.length,
-        entries: recent.map(e => ({
-          id: e.id,
-          preview: e.pattern.substring(0, 60) + (e.pattern.length > 60 ? '...' : ''),
-          chars: e.pattern.length,
-          action: e.action,
-          timestamp: formatTimeAgo(e.timestamp),
-        })),
-      };
     }
 
-    case 'restore_history': {
-      if (!sid && !ctx.isInitialized()) return 'Browser not initialized. Run init first.';
-      const controller = ctx.getController(sid);
-
-      const entry = historyStack.find(e => e.id === args.id);
-      if (!entry) {
-        return `History entry #${args.id} not found. Use list_history to see available entries.`;
-      }
-
-      const current = await controller.getCurrentPattern();
-      undoStack.push(current);
-      if (undoStack.length > maxHistory) undoStack.shift();
-
-      await controller.writePattern(entry.pattern);
-      return `Restored pattern from history #${args.id} (${formatTimeAgo(entry.timestamp)})`;
-    }
-
-    case 'compare_patterns': {
-      const first = historyStack.find(e => e.id === args.id1);
-      if (!first) return `History entry #${args.id1} not found.`;
-
-      let second: string;
-      let label: string;
-      if (args.id2) {
-        const b = historyStack.find(e => e.id === args.id2);
-        if (!b) return `History entry #${args.id2} not found.`;
-        second = b.pattern;
-        label = `#${args.id2}`;
-      } else {
-        second = await ctx.getCurrentPatternSafe(sid);
-        label = 'current';
-      }
-
-      return {
-        pattern1: { id: args.id1, chars: first.pattern.length },
-        pattern2: { id: label, chars: second.length },
-        diff: generateDiff(first.pattern, second),
-        summary: summarizeDiff(first.pattern, second),
-      };
-    }
+    // Deprecated aliases — forward to consolidated handler.
+    case 'undo':             return await doUndo(ctx, sid);
+    case 'redo':             return await doRedo(ctx, sid);
+    case 'list_history':     return doList(args, ctx);
+    case 'restore_history':  return await doRestore(args, ctx, sid);
+    case 'compare_patterns': return await doCompare(args, ctx, sid);
 
     default:
       throw new Error(`history module does not handle tool: ${name}`);


### PR DESCRIPTION
Third installment of #120. Closes #145. **Phase 1 of the consolidation epic is now complete** (alongside #143 pattern_store + #144 diagnostics).

## Summary

Single \`history(action)\` tool replaces five legacy verbs. The legacy tools remain as deprecated aliases that forward to the new handler.

| Action | Old equivalent |
|---|---|
| \`undo\` | \`undo\` |
| \`redo\` | \`redo\` |
| \`list\` | \`list_history\` |
| \`restore\` | \`restore_history\` |
| \`compare\` | \`compare_patterns\` |

**Note** (also documented in #145): undo/redo/history stacks remain server-wide. Named sessions read/write through the right controller but share the underlying stacks. Per-session stacks are tracked separately as future work — out of scope for the consolidation.

## Test plan

- [x] 18 new cases in \`HistoryConsolidation.test.ts\` cover every action, default behaviour, error paths, alias-forwarding equivalence, init refusal, and the compare-vs-current path
- [x] \`tsc --noEmit\` clean
- [x] Full suite: 1610 pass, 20 skipped, 0 fail
- [x] \`npm run lint\` clean (0 errors, 132 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

Tool count: 71 → 72 during deprecation; -5 once aliases removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)