### PR TITLE
feat(#146): consolidate audio analysis tools → analyze(include[])

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `analyze` | Complete audio analysis |
-| `analyze_spectrum` | FFT spectrum analysis |
-| `analyze_rhythm` | Rhythm analysis |
-| `detect_tempo` | BPM detection |
-| `detect_key` | Key detection |
+| `analyze` | Audio analysis on the currently-playing pattern.  |
+| `analyze_spectrum` | [DEPRECATED — use analyze({ include: ["spectrum"] }) instead] FFT spectrum analysis |
+| `analyze_rhythm` | [DEPRECATED — use analyze({ include: ["rhythm"] }) instead] Rhythm analysis |
+| `detect_tempo` | [DEPRECATED — use analyze({ include: ["tempo"] }) instead] BPM detection |
+| `detect_key` | [DEPRECATED — use analyze({ include: ["key"] }) instead] Key detection |
 | `validate_pattern_runtime` | Validate pattern with runtime error checking (monitors Strudel console for errors) |
 | `compare_patterns` | [DEPRECATED — use history({ action: "compare" }) instead] Compare two patterns from history showing differences |
 

--- a/src/__tests__/unit/AnalyzeConsolidation.test.ts
+++ b/src/__tests__/unit/AnalyzeConsolidation.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the analyze consolidation (#146).
+ *
+ * analyze(include[]) replaces analyze_spectrum / analyze_rhythm /
+ * detect_tempo / detect_key. include=['all'] (default) preserves
+ * pre-consolidation behaviour. Other include sets return an object
+ * keyed by category.
+ */
+
+import { execute } from '../../server/tools/analysis';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx(initialized = true) {
+  const controller = {
+    analyzeAudio: jest.fn(async () => ({
+      features: { bass: 50, mid: 40, treble: 30, brightness: 'balanced' },
+      timestamp: 1234,
+    })),
+    analyzeRhythm: jest.fn(async () => ({ complexity: 0.6, density: 4, syncopation: 0.2 })),
+    detectTempo: jest.fn(async () => ({ bpm: 128, confidence: 0.93, method: 'onset' })),
+    detectKey: jest.fn(async () => ({
+      key: 'C', scale: 'major', confidence: 0.81,
+      alternatives: [{ key: 'A', scale: 'minor', confidence: 0.72 }],
+    })),
+    validatePatternRuntime: jest.fn(),
+  };
+  const ctx: ToolContext = {
+    controller: controller as any,
+    perfMonitor: {} as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {
+      validate: jest.fn(),
+      analyzePattern: jest.fn(),
+      queryEvents: jest.fn(),
+      transpile: jest.fn(),
+    } as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => initialized,
+    ensureInitialized: async () => {},
+    getController: () => controller as any,
+    getCurrentPatternSafe: async () => '',
+    writePatternSafe: async () => 'written',
+  };
+  return { ctx, controller };
+}
+
+describe('analyze consolidation (#146)', () => {
+  describe('analyze(include)', () => {
+    it('default include=["all"] returns full analyzeAudio result', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = await execute('analyze', {}, ctx);
+      expect(result).toEqual({
+        features: { bass: 50, mid: 40, treble: 30, brightness: 'balanced' },
+        timestamp: 1234,
+      });
+      expect(controller.analyzeAudio).toHaveBeenCalledTimes(1);
+      // Detection helpers should NOT be called for include=all
+      expect(controller.detectTempo).not.toHaveBeenCalled();
+      expect(controller.detectKey).not.toHaveBeenCalled();
+    });
+
+    it('explicit include=["all"] matches default', async () => {
+      const { ctx } = makeCtx();
+      const a = await execute('analyze', {}, ctx);
+      const b = await execute('analyze', { include: ['all'] }, ctx);
+      expect(a).toEqual(b);
+    });
+
+    it('include=["spectrum"] returns just features', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = (await execute('analyze', { include: ['spectrum'] }, ctx)) as any;
+      expect(result.spectrum).toEqual({ bass: 50, mid: 40, treble: 30, brightness: 'balanced' });
+      expect(controller.analyzeAudio).toHaveBeenCalledTimes(1);
+      expect(controller.detectTempo).not.toHaveBeenCalled();
+    });
+
+    it('include=["tempo"] returns just tempo result', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = (await execute('analyze', { include: ['tempo'] }, ctx)) as any;
+      expect(result.tempo.bpm).toBe(128);
+      expect(result.tempo.confidence).toBe(0.93);
+      expect(controller.detectKey).not.toHaveBeenCalled();
+      expect(controller.analyzeAudio).not.toHaveBeenCalled();
+    });
+
+    it('include=["key"] returns just key result', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = (await execute('analyze', { include: ['key'] }, ctx)) as any;
+      expect(result.key.key).toBe('C');
+      expect(result.key.scale).toBe('major');
+      expect(result.key.alternatives).toHaveLength(1);
+      expect(controller.detectTempo).not.toHaveBeenCalled();
+    });
+
+    it('include=["rhythm"] returns just rhythm result', async () => {
+      const { ctx } = makeCtx();
+      const result = (await execute('analyze', { include: ['rhythm'] }, ctx)) as any;
+      expect(result.rhythm.complexity).toBe(0.6);
+    });
+
+    it('include=["tempo","key"] returns both keyed', async () => {
+      const { ctx, controller } = makeCtx();
+      const result = (await execute('analyze', { include: ['tempo', 'key'] }, ctx)) as any;
+      expect(result.tempo.bpm).toBe(128);
+      expect(result.key.key).toBe('C');
+      expect(controller.detectTempo).toHaveBeenCalledTimes(1);
+      expect(controller.detectKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws on invalid include value', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('analyze', { include: ['bogus'] }, ctx)).rejects.toThrow(/Invalid include/);
+    });
+
+    it('refuses when default session not initialized', async () => {
+      const { ctx } = makeCtx(false);
+      const result = await execute('analyze', { include: ['tempo'] }, ctx);
+      expect(result).toContain('not initialized');
+    });
+
+    it('tempo returns 0 BPM with friendly message when detector returns 0', async () => {
+      const { ctx, controller } = makeCtx();
+      (controller.detectTempo as jest.Mock).mockResolvedValueOnce({ bpm: 0, confidence: 0 });
+      const result = (await execute('analyze', { include: ['tempo'] }, ctx)) as any;
+      expect(result.tempo.bpm).toBe(0);
+      expect(result.tempo.message).toContain('No tempo detected');
+    });
+
+    it('key returns "Unknown" with friendly message when confidence below threshold', async () => {
+      const { ctx, controller } = makeCtx();
+      (controller.detectKey as jest.Mock).mockResolvedValueOnce({ key: 'X', scale: 'major', confidence: 0.05 });
+      const result = (await execute('analyze', { include: ['key'] }, ctx)) as any;
+      expect(result.key.key).toBe('Unknown');
+    });
+  });
+
+  describe('legacy aliases forward (deprecation window)', () => {
+    it('analyze_spectrum matches analyze({ include: ["spectrum"] }) inner value', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('analyze_spectrum', {}, ctx);
+      const direct = (await execute('analyze', { include: ['spectrum'] }, ctx)) as any;
+      expect(alias).toEqual(direct.spectrum);
+    });
+
+    it('analyze_rhythm matches analyze({ include: ["rhythm"] }) inner value', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('analyze_rhythm', {}, ctx);
+      const direct = (await execute('analyze', { include: ['rhythm'] }, ctx)) as any;
+      expect(alias).toEqual(direct.rhythm);
+    });
+
+    it('detect_tempo matches analyze({ include: ["tempo"] }) inner value', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('detect_tempo', {}, ctx);
+      const direct = (await execute('analyze', { include: ['tempo'] }, ctx)) as any;
+      expect(alias).toEqual(direct.tempo);
+    });
+
+    it('detect_key matches analyze({ include: ["key"] }) inner value', async () => {
+      const { ctx } = makeCtx();
+      const alias = await execute('detect_key', {}, ctx);
+      const direct = (await execute('analyze', { include: ['key'] }, ctx)) as any;
+      expect(alias).toEqual(direct.key);
+    });
+  });
+});

--- a/src/server/tools/analysis.ts
+++ b/src/server/tools/analysis.ts
@@ -31,27 +31,46 @@ const SESSION_ID_PROP = {
 export const tools: Tool[] = [
   {
     name: 'analyze',
-    description: 'Complete audio analysis',
-    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
+    description:
+      'Audio analysis on the currently-playing pattern. ' +
+      'include=["all"] (default) returns the full spectrum + features object, matching the pre-consolidation behaviour. ' +
+      'include=["tempo"] returns only BPM with confidence. ' +
+      'include=["key"] returns detected key + scale + confidence. ' +
+      'include=["spectrum"] returns FFT features (bass, mid, treble, brightness, etc.). ' +
+      'include=["rhythm"] returns rhythm-only analysis (complexity, density, syncopation). ' +
+      'Combining values returns an object keyed by category, e.g. analyze({ include: ["tempo", "key"] }) → { tempo: {...}, key: {...} }. ' +
+      'Example: analyze({ include: ["tempo"] }) to cheaply re-check BPM during a session. ' +
+      'For static pattern analysis (no browser) use analyze_pattern_local; for runtime validation use validate_pattern_runtime.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        include: {
+          type: 'array',
+          items: { type: 'string', enum: ['all', 'spectrum', 'rhythm', 'tempo', 'key'] },
+          description: 'Which analyses to return. Default ["all"] preserves pre-consolidation behaviour.',
+        },
+        ...SESSION_ID_PROP,
+      },
+    },
   },
   {
     name: 'analyze_spectrum',
-    description: 'FFT spectrum analysis',
+    description: '[DEPRECATED — use analyze({ include: ["spectrum"] }) instead] FFT spectrum analysis',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'analyze_rhythm',
-    description: 'Rhythm analysis',
+    description: '[DEPRECATED — use analyze({ include: ["rhythm"] }) instead] Rhythm analysis',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'detect_tempo',
-    description: 'BPM detection',
+    description: '[DEPRECATED — use analyze({ include: ["tempo"] }) instead] BPM detection',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'detect_key',
-    description: 'Key detection',
+    description: '[DEPRECATED — use analyze({ include: ["key"] }) instead] Key detection',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
@@ -125,6 +144,99 @@ const LOCAL_ENGINE_TOOLS = new Set([
   'transpile_pattern',
 ]);
 
+async function getSpectrum(controller: any): Promise<unknown> {
+  const spectrum = await controller.analyzeAudio();
+  return spectrum.features || spectrum;
+}
+
+async function getRhythm(controller: any): Promise<unknown> {
+  return await controller.analyzeRhythm();
+}
+
+async function getTempo(controller: any): Promise<unknown> {
+  try {
+    const tempoAnalysis = await controller.detectTempo();
+    if (!tempoAnalysis || tempoAnalysis.bpm === 0) {
+      return {
+        bpm: 0,
+        confidence: 0,
+        message: 'No tempo detected. Ensure audio is playing and has a clear rhythmic pattern.',
+      };
+    }
+    return {
+      bpm: tempoAnalysis.bpm,
+      confidence: Math.round(tempoAnalysis.confidence * 100) / 100,
+      method: tempoAnalysis.method,
+      message: `Detected ${tempoAnalysis.bpm} BPM with ${Math.round(tempoAnalysis.confidence * 100)}% confidence`,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { bpm: 0, confidence: 0, error: message || 'Tempo detection failed' };
+  }
+}
+
+async function getKey(controller: any): Promise<unknown> {
+  try {
+    const keyAnalysis = await controller.detectKey();
+    if (!keyAnalysis || keyAnalysis.confidence < 0.1) {
+      return {
+        key: 'Unknown',
+        scale: 'unknown',
+        confidence: 0,
+        message: 'No clear key detected. Ensure audio is playing and has tonal content.',
+      };
+    }
+    const result: any = {
+      key: keyAnalysis.key,
+      scale: keyAnalysis.scale,
+      confidence: Math.round(keyAnalysis.confidence * 100) / 100,
+      message: `Detected ${keyAnalysis.key} ${keyAnalysis.scale} with ${Math.round(keyAnalysis.confidence * 100)}% confidence`,
+    };
+    if (keyAnalysis.alternatives && keyAnalysis.alternatives.length > 0) {
+      result.alternatives = keyAnalysis.alternatives.map((alt: any) => ({
+        key: alt.key,
+        scale: alt.scale,
+        confidence: Math.round(alt.confidence * 100) / 100,
+      }));
+    }
+    return result;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { key: 'Unknown', scale: 'unknown', confidence: 0, error: message || 'Key detection failed' };
+  }
+}
+
+async function doAnalyze(args: any, controller: any): Promise<unknown> {
+  const includeRaw: unknown = args?.include;
+  const include: string[] = Array.isArray(includeRaw) && includeRaw.length > 0
+    ? (includeRaw as string[])
+    : ['all'];
+
+  for (const v of include) {
+    if (!['all', 'spectrum', 'rhythm', 'tempo', 'key'].includes(v)) {
+      throw new Error(`Invalid include value: ${v}. Must be one of: all, spectrum, rhythm, tempo, key`);
+    }
+  }
+
+  // include=['all'] is the most-common path and returns the unwrapped
+  // analyzeAudio result (no schema surprise vs old `analyze`).
+  if (include.includes('all')) {
+    return await controller.analyzeAudio();
+  }
+
+  // Otherwise return an object keyed by category, computed in parallel.
+  const tasks: Record<string, Promise<unknown>> = {};
+  if (include.includes('spectrum')) tasks.spectrum = getSpectrum(controller);
+  if (include.includes('rhythm'))   tasks.rhythm   = getRhythm(controller);
+  if (include.includes('tempo'))    tasks.tempo    = getTempo(controller);
+  if (include.includes('key'))      tasks.key      = getKey(controller);
+
+  const entries = await Promise.all(
+    Object.entries(tasks).map(async ([k, p]) => [k, await p] as const),
+  );
+  return Object.fromEntries(entries);
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
   if (!LOCAL_ENGINE_TOOLS.has(name) && !sid && !ctx.isInitialized()) {
@@ -134,68 +246,13 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
 
   switch (name) {
     case 'analyze':
-      return await controller!.analyzeAudio();
+      return await doAnalyze(args, controller!);
 
-    case 'analyze_spectrum': {
-      const spectrum = await controller!.analyzeAudio();
-      return spectrum.features || spectrum;
-    }
-
-    case 'analyze_rhythm':
-      return await controller!.analyzeRhythm();
-
-    case 'detect_tempo': {
-      try {
-        const tempoAnalysis = await controller!.detectTempo();
-        if (!tempoAnalysis || tempoAnalysis.bpm === 0) {
-          return {
-            bpm: 0,
-            confidence: 0,
-            message: 'No tempo detected. Ensure audio is playing and has a clear rhythmic pattern.',
-          };
-        }
-        return {
-          bpm: tempoAnalysis.bpm,
-          confidence: Math.round(tempoAnalysis.confidence * 100) / 100,
-          method: tempoAnalysis.method,
-          message: `Detected ${tempoAnalysis.bpm} BPM with ${Math.round(tempoAnalysis.confidence * 100)}% confidence`,
-        };
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        return { bpm: 0, confidence: 0, error: message || 'Tempo detection failed' };
-      }
-    }
-
-    case 'detect_key': {
-      try {
-        const keyAnalysis = await controller!.detectKey();
-        if (!keyAnalysis || keyAnalysis.confidence < 0.1) {
-          return {
-            key: 'Unknown',
-            scale: 'unknown',
-            confidence: 0,
-            message: 'No clear key detected. Ensure audio is playing and has tonal content.',
-          };
-        }
-        const result: any = {
-          key: keyAnalysis.key,
-          scale: keyAnalysis.scale,
-          confidence: Math.round(keyAnalysis.confidence * 100) / 100,
-          message: `Detected ${keyAnalysis.key} ${keyAnalysis.scale} with ${Math.round(keyAnalysis.confidence * 100)}% confidence`,
-        };
-        if (keyAnalysis.alternatives && keyAnalysis.alternatives.length > 0) {
-          result.alternatives = keyAnalysis.alternatives.map((alt: any) => ({
-            key: alt.key,
-            scale: alt.scale,
-            confidence: Math.round(alt.confidence * 100) / 100,
-          }));
-        }
-        return result;
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        return { key: 'Unknown', scale: 'unknown', confidence: 0, error: message || 'Key detection failed' };
-      }
-    }
+    // Deprecated aliases — forward to consolidated handler.
+    case 'analyze_spectrum': return await getSpectrum(controller!);
+    case 'analyze_rhythm':   return await getRhythm(controller!);
+    case 'detect_tempo':     return await getTempo(controller!);
+    case 'detect_key':       return await getKey(controller!);
 
     case 'validate_pattern_runtime': {
       InputValidator.validateStringLength(args.pattern, 'pattern', 10000, false);


### PR DESCRIPTION
First Phase 2 installment of #120. Closes #146.

Adds an \`include[]\` filter to the existing \`analyze\` tool. The four detection verbs become deprecated aliases.

## Semantics

| Call | Returns |
|---|---|
| \`analyze({ include: ['all'] })\` (default) | Raw analyzeAudio dump — **byte-for-byte equivalent to old analyze** |
| \`analyze({ include: ['spectrum'] })\` | \`{ spectrum: { ...features } }\` |
| \`analyze({ include: ['rhythm'] })\` | \`{ rhythm: {...} }\` |
| \`analyze({ include: ['tempo'] })\` | \`{ tempo: { bpm, confidence, ... } }\` |
| \`analyze({ include: ['key'] })\` | \`{ key: { key, scale, confidence, alternatives } }\` |
| \`analyze({ include: ['tempo','key'] })\` | \`{ tempo: {...}, key: {...} }\` |

Subset includes run their detectors in parallel via Promise.all.

The 4 detection helpers were extracted to private functions so both the new tool and alias paths share one source of truth.

## Test plan

- [x] 15 new cases in \`AnalyzeConsolidation.test.ts\` — include semantics, default behaviour, alias forwarding equivalence, error paths, not-initialized handling
- [x] \`tsc --noEmit\` clean
- [x] Full suite: 1641 pass, 20 skipped, 0 fail
- [x] \`npm run lint\` clean (0 errors, 138 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)