### PR TITLE
feat(#148): consolidate write/append/insert/replace/clear → edit_pattern(mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-72-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-73-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -197,7 +197,7 @@ Then ask Claude:
 
 <!-- TOOLS:START -->
 
-**72 tools** across 15 categories:
+**73 tools** across 15 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -211,11 +211,11 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `write` | Write pattern to editor with optional auto-play and validation |
-| `append` | Append code to current pattern |
-| `insert` | Insert code at specific line |
-| `replace` | Replace pattern section |
 | `get_pattern` | Get current pattern code |
+| `write` | [DEPRECATED — use edit_pattern({ mode: "write" }) instead] Write pattern to editor with optional auto-play and validation |
+| `append` | [DEPRECATED — use edit_pattern({ mode: "append" }) instead] Append code to current pattern |
+| `insert` | [DEPRECATED — use edit_pattern({ mode: "insert" }) instead] Insert code at specific line |
+| `replace` | [DEPRECATED — use edit_pattern({ mode: "replace" }) instead] Replace pattern section |
 
 </details>
 
@@ -224,7 +224,7 @@ Then ask Claude:
 | Tool | Description |
 |------|-------------|
 | `status` | [DEPRECATED — use diagnostics({ level: "status" }) instead] Get current browser and playback status (quick state check) |
-| `clear` | Clear the editor |
+| `clear` | [DEPRECATED — use edit_pattern({ mode: "clear" }) instead] Clear the editor |
 | `play` | Start playing pattern |
 | `pause` | Pause playback |
 | `stop` | Stop playback |
@@ -362,7 +362,7 @@ Then ask Claude:
 
 </details>
 
-<details><summary><strong>Other</strong> (7)</summary>
+<details><summary><strong>Other</strong> (8)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -371,12 +371,13 @@ Then ask Claude:
 | `analyze_pattern_local` | Static analysis (events/cycle, complexity, optional BPM) without browser playback |
 | `query_pattern_events` | Enumerate events the pattern would emit between two cycle indices (max 16 cycles) |
 | `transpile_pattern` | Transpile pattern source via StrudelEngine; returns transpiled code or syntax error |
+| `edit_pattern` | Mutate the current session pattern.  |
 | `history` | Navigate or inspect the pattern edit history.  |
 | `pattern_store` | Persist patterns to disk and read them back.  |
 
 </details>
 
-_Auto-generated from source. 72 tools registered._
+_Auto-generated from source. 73 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/src/__tests__/unit/EditPatternConsolidation.test.ts
+++ b/src/__tests__/unit/EditPatternConsolidation.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the edit_pattern consolidation (#148).
+ *
+ * edit_pattern(mode) replaces write/append/insert/replace/clear.
+ * get_pattern stays separate (hot read path, not touched).
+ */
+
+import { execute } from '../../server/tools/editor';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx(initialized = true) {
+  let pattern = 's("bd")';
+  let played = false;
+  const controller = {
+    validatePattern: jest.fn(async () => ({ valid: true, errors: [], warnings: [], suggestions: [] })),
+    play: jest.fn(async () => { played = true; }),
+  };
+  const ctx: ToolContext = {
+    controller: controller as any,
+    perfMonitor: {} as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => initialized,
+    ensureInitialized: async () => {},
+    getController: () => controller as any,
+    getCurrentPatternSafe: async () => pattern,
+    writePatternSafe: async (p: string) => { pattern = p; return 'written'; },
+  };
+  return { ctx, controller, pattern: () => pattern, played: () => played };
+}
+
+describe('edit_pattern consolidation (#148)', () => {
+  describe('edit_pattern(mode)', () => {
+    it('default mode is write', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('edit_pattern', { pattern: 'new pattern' }, ctx);
+      expect(pattern()).toBe('new pattern');
+    });
+
+    it('mode=write replaces editor contents', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('edit_pattern', { mode: 'write', pattern: 'fresh' }, ctx);
+      expect(pattern()).toBe('fresh');
+    });
+
+    it('mode=write runs pattern validation by default', async () => {
+      const { ctx, controller } = makeCtx();
+      await execute('edit_pattern', { mode: 'write', pattern: 'x' }, ctx);
+      expect(controller.validatePattern).toHaveBeenCalledWith('x');
+    });
+
+    it('mode=write returns validation failure object when validation fails', async () => {
+      const { ctx, controller } = makeCtx();
+      (controller.validatePattern as jest.Mock).mockResolvedValueOnce({
+        valid: false,
+        errors: ['bad syntax'],
+        warnings: [],
+        suggestions: ['try this'],
+      });
+      const result = (await execute('edit_pattern', { mode: 'write', pattern: 'bad' }, ctx)) as any;
+      expect(result.success).toBe(false);
+      expect(result.errors).toContain('bad syntax');
+    });
+
+    it('mode=write with auto_play triggers play', async () => {
+      const { ctx, played } = makeCtx();
+      const result = await execute('edit_pattern', { mode: 'write', pattern: 'x', auto_play: true }, ctx);
+      expect(played()).toBe(true);
+      expect(result as string).toContain('Playing');
+    });
+
+    it('mode=write with validate=false skips validation', async () => {
+      const { ctx, controller } = makeCtx();
+      await execute('edit_pattern', { mode: 'write', pattern: 'x', validate: false }, ctx);
+      expect(controller.validatePattern).not.toHaveBeenCalled();
+    });
+
+    it('mode=append concatenates with newline', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('edit_pattern', { mode: 'append', code: '.fast(2)' }, ctx);
+      expect(pattern()).toBe('s("bd")\n.fast(2)');
+    });
+
+    it('mode=insert places code at the given line', async () => {
+      const { ctx, pattern } = makeCtx();
+      // Use position=1 — validator requires a positive integer
+      await execute('edit_pattern', { mode: 'insert', position: 1, code: 'setcpm(140)' }, ctx);
+      // splice at index 1 inserts after the first line; pattern starts as one line `s("bd")`
+      expect(pattern()).toContain('setcpm(140)');
+    });
+
+    it('mode=replace does string substitution', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('edit_pattern', { mode: 'replace', search: 'bd', replace: 'sd' }, ctx);
+      expect(pattern()).toBe('s("sd")');
+    });
+
+    it('mode=clear empties the editor', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('edit_pattern', { mode: 'clear' }, ctx);
+      expect(pattern()).toBe('');
+    });
+
+    it('throws on invalid mode', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('edit_pattern', { mode: 'delete', pattern: 'x' }, ctx)).rejects.toThrow(/Invalid mode/);
+    });
+
+    it('refuses when default session not initialized', async () => {
+      const { ctx } = makeCtx(false);
+      const result = await execute('edit_pattern', { mode: 'write', pattern: 'x' }, ctx);
+      expect(result).toContain('not initialized');
+    });
+  });
+
+  describe('legacy aliases forward (deprecation window)', () => {
+    it('write alias produces identical result to edit_pattern(mode=write)', async () => {
+      const { ctx: ctxA, pattern: patA } = makeCtx();
+      const { ctx: ctxB, pattern: patB } = makeCtx();
+      await execute('write', { pattern: 'alias' }, ctxA);
+      await execute('edit_pattern', { mode: 'write', pattern: 'alias' }, ctxB);
+      expect(patA()).toBe(patB());
+    });
+
+    it('append alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('append', { code: '.rev' }, ctx);
+      expect(pattern()).toBe('s("bd")\n.rev');
+    });
+
+    it('insert alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('insert', { position: 1, code: 'next' }, ctx);
+      expect(pattern()).toContain('next');
+    });
+
+    it('replace alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('replace', { search: 'bd', replace: 'hh' }, ctx);
+      expect(pattern()).toBe('s("hh")');
+    });
+
+    it('clear alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('clear', {}, ctx);
+      expect(pattern()).toBe('');
+    });
+  });
+
+  describe('get_pattern stays distinct (hot read path)', () => {
+    it('get_pattern returns current contents without mutating', async () => {
+      const { ctx, pattern } = makeCtx();
+      const result = await execute('get_pattern', {}, ctx);
+      expect(result).toBe('s("bd")');
+      expect(pattern()).toBe('s("bd")');
+    });
+  });
+});

--- a/src/server/tools/editor.ts
+++ b/src/server/tools/editor.ts
@@ -1,10 +1,12 @@
 /**
  * editor domain — pattern editing in the CodeMirror editor.
  *
- * Owns (6 tools): write, append, insert, replace, clear, get_pattern.
- * Post-consolidation per the #110 audit: the five mutating tools
- * collapse into an `edit_pattern` tool with a `mode` enum, while
- * `get_pattern` stays separate (hot read path).
+ * Owns one consolidated mutation tool (`edit_pattern(mode)`) plus
+ * `get_pattern` (kept separate, hot read path) and five deprecated
+ * aliases (write/append/insert/replace/clear) per #120 / #148.
+ *
+ * Aliases forward to `edit_pattern` and will be removed in a future
+ * release per the deprecation policy.
  */
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -20,8 +22,43 @@ const SESSION_ID_PROP = {
 
 export const tools: Tool[] = [
   {
+    name: 'edit_pattern',
+    description:
+      'Mutate the current session pattern. ' +
+      'mode=write replaces the editor contents (default; mirrors the old write tool exactly, including optional pattern validation and auto_play). ' +
+      'mode=append concatenates `code` after the current pattern with a newline. ' +
+      'mode=insert places `code` at the given line `position`. ' +
+      'mode=replace runs a single string-replace from `search` to `replace`. ' +
+      'mode=clear empties the editor. ' +
+      'Example: edit_pattern({ mode: "write", pattern: "s(\\"bd\\")", auto_play: true }). ' +
+      'For reading the editor without mutating it use get_pattern; for the on-disk pattern catalog use pattern_store.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: {
+          type: 'string',
+          enum: ['write', 'append', 'insert', 'replace', 'clear'],
+          description: 'Which edit operation to perform (default: write)',
+        },
+        pattern: { type: 'string', description: 'Pattern code (mode=write)' },
+        code: { type: 'string', description: 'Code to append/insert (mode=append/insert)' },
+        position: { type: 'number', description: 'Line number (mode=insert)' },
+        search: { type: 'string', description: 'Text to replace (mode=replace)' },
+        replace: { type: 'string', description: 'Replacement text (mode=replace)' },
+        auto_play: { type: 'boolean', description: 'Start playback after write (mode=write only, default: false)' },
+        validate: { type: 'boolean', description: 'Validate pattern before write (mode=write only, default: true)' },
+        ...SESSION_ID_PROP,
+      },
+    },
+  },
+  {
+    name: 'get_pattern',
+    description: 'Get current pattern code',
+    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
+  },
+  {
     name: 'write',
-    description: 'Write pattern to editor with optional auto-play and validation',
+    description: '[DEPRECATED — use edit_pattern({ mode: "write" }) instead] Write pattern to editor with optional auto-play and validation',
     inputSchema: {
       type: 'object',
       properties: {
@@ -35,7 +72,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'append',
-    description: 'Append code to current pattern',
+    description: '[DEPRECATED — use edit_pattern({ mode: "append" }) instead] Append code to current pattern',
     inputSchema: {
       type: 'object',
       properties: { code: { type: 'string', description: 'Code to append' }, ...SESSION_ID_PROP },
@@ -44,7 +81,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'insert',
-    description: 'Insert code at specific line',
+    description: '[DEPRECATED — use edit_pattern({ mode: "insert" }) instead] Insert code at specific line',
     inputSchema: {
       type: 'object',
       properties: {
@@ -57,7 +94,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'replace',
-    description: 'Replace pattern section',
+    description: '[DEPRECATED — use edit_pattern({ mode: "replace" }) instead] Replace pattern section',
     inputSchema: {
       type: 'object',
       properties: {
@@ -70,17 +107,73 @@ export const tools: Tool[] = [
   },
   {
     name: 'clear',
-    description: 'Clear the editor',
-    inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
-  },
-  {
-    name: 'get_pattern',
-    description: 'Get current pattern code',
+    description: '[DEPRECATED — use edit_pattern({ mode: "clear" }) instead] Clear the editor',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
 ];
 
 export const toolNames = new Set(tools.map(t => t.name));
+
+async function doWrite(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.pattern, 'pattern', 10000, true);
+
+  const controller = ctx.getController(sid);
+
+  // Validate pattern if requested (default: true) — issue #40
+  if (args.validate !== false && typeof controller.validatePattern === 'function') {
+    try {
+      const validation = await controller.validatePattern(args.pattern);
+      if (validation && !validation.valid) {
+        return {
+          success: false,
+          errors: validation.errors,
+          warnings: validation.warnings,
+          suggestions: validation.suggestions,
+          message: `Pattern validation failed: ${validation.errors.join('; ')}`,
+        };
+      }
+    } catch {
+      ctx.logger.warn('Pattern validation threw error, continuing with write');
+    }
+  }
+
+  const writeResult = await ctx.writePatternSafe(args.pattern, sid);
+
+  // Auto-play if requested — issue #38
+  if (args.auto_play) {
+    await controller.play();
+    return `${writeResult}. Playing.`;
+  }
+  return writeResult;
+}
+
+async function doAppend(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.code, 'code', 10000, true);
+  const current = await ctx.getCurrentPatternSafe(sid);
+  return await ctx.writePatternSafe(current + '\n' + args.code, sid);
+}
+
+async function doInsert(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validatePositiveInteger(args.position, 'position');
+  InputValidator.validateStringLength(args.code, 'code', 10000, true);
+  const lines = (await ctx.getCurrentPatternSafe(sid)).split('\n');
+  lines.splice(args.position, 0, args.code);
+  return await ctx.writePatternSafe(lines.join('\n'), sid);
+}
+
+async function doReplace(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.search, 'search', 1000, true);
+  InputValidator.validateStringLength(args.replace, 'replace', 10000, true);
+  const pattern = await ctx.getCurrentPatternSafe(sid);
+  // Escape $ in replacement to prevent special sequence injection ($&, $1, $', etc.)
+  const safeReplacement = args.replace.replace(/\$/g, '$$$$');
+  const replaced = pattern.replace(args.search, safeReplacement);
+  return await ctx.writePatternSafe(replaced, sid);
+}
+
+async function doClear(ctx: ToolContext, sid?: string): Promise<unknown> {
+  return await ctx.writePatternSafe('', sid);
+}
 
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
@@ -88,65 +181,25 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
     return 'Browser not initialized. Run init first.';
   }
   switch (name) {
-    case 'write': {
-      InputValidator.validateStringLength(args.pattern, 'pattern', 10000, true);
-
-      const controller = ctx.getController(sid);
-
-      // Validate pattern if requested (default: true) — issue #40
-      if (args.validate !== false && typeof controller.validatePattern === 'function') {
-        try {
-          const validation = await controller.validatePattern(args.pattern);
-          if (validation && !validation.valid) {
-            return {
-              success: false,
-              errors: validation.errors,
-              warnings: validation.warnings,
-              suggestions: validation.suggestions,
-              message: `Pattern validation failed: ${validation.errors.join('; ')}`,
-            };
-          }
-        } catch {
-          ctx.logger.warn('Pattern validation threw error, continuing with write');
-        }
+    case 'edit_pattern': {
+      const mode = args?.mode ?? 'write';
+      switch (mode) {
+        case 'write':   return await doWrite(args, ctx, sid);
+        case 'append':  return await doAppend(args, ctx, sid);
+        case 'insert':  return await doInsert(args, ctx, sid);
+        case 'replace': return await doReplace(args, ctx, sid);
+        case 'clear':   return await doClear(ctx, sid);
+        default:
+          throw new Error(`Invalid mode: ${mode}. Must be one of: write, append, insert, replace, clear`);
       }
-
-      const writeResult = await ctx.writePatternSafe(args.pattern, sid);
-
-      // Auto-play if requested — issue #38
-      if (args.auto_play) {
-        await controller.play();
-        return `${writeResult}. Playing.`;
-      }
-      return writeResult;
     }
 
-    case 'append': {
-      InputValidator.validateStringLength(args.code, 'code', 10000, true);
-      const current = await ctx.getCurrentPatternSafe(sid);
-      return await ctx.writePatternSafe(current + '\n' + args.code, sid);
-    }
-
-    case 'insert': {
-      InputValidator.validatePositiveInteger(args.position, 'position');
-      InputValidator.validateStringLength(args.code, 'code', 10000, true);
-      const lines = (await ctx.getCurrentPatternSafe(sid)).split('\n');
-      lines.splice(args.position, 0, args.code);
-      return await ctx.writePatternSafe(lines.join('\n'), sid);
-    }
-
-    case 'replace': {
-      InputValidator.validateStringLength(args.search, 'search', 1000, true);
-      InputValidator.validateStringLength(args.replace, 'replace', 10000, true);
-      const pattern = await ctx.getCurrentPatternSafe(sid);
-      // Escape $ in replacement to prevent special sequence injection ($&, $1, $', etc.)
-      const safeReplacement = args.replace.replace(/\$/g, '$$$$');
-      const replaced = pattern.replace(args.search, safeReplacement);
-      return await ctx.writePatternSafe(replaced, sid);
-    }
-
-    case 'clear':
-      return await ctx.writePatternSafe('', sid);
+    // Deprecated aliases — forward to consolidated handler.
+    case 'write':   return await doWrite(args, ctx, sid);
+    case 'append':  return await doAppend(args, ctx, sid);
+    case 'insert':  return await doInsert(args, ctx, sid);
+    case 'replace': return await doReplace(args, ctx, sid);
+    case 'clear':   return await doClear(ctx, sid);
 
     case 'get_pattern':
       return await ctx.getCurrentPatternSafe(sid);


### PR DESCRIPTION
Second Phase 2 installment of #120. Closes #148.

Single \`edit_pattern(mode)\` tool replaces the five mutating verbs. \`get_pattern\` stays separate per the audit (hot read path). All five mutating verbs become deprecated aliases.

## Modes

| Call | Old equivalent |
|---|---|
| \`edit_pattern({ mode: 'write', pattern, auto_play?, validate? })\` | \`write\` |
| \`edit_pattern({ mode: 'append', code })\` | \`append\` |
| \`edit_pattern({ mode: 'insert', position, code })\` | \`insert\` |
| \`edit_pattern({ mode: 'replace', search, replace })\` | \`replace\` |
| \`edit_pattern({ mode: 'clear' })\` | \`clear\` |

Default \`mode='write'\` so calls passing \`pattern\` without specifying mode behave exactly like the old \`write\` tool — same validation, same auto_play, same response shape.

Each handler was extracted to a private function so the new tool and the five alias paths share one source of truth.

## Test plan

- [x] 18 new cases in \`EditPatternConsolidation.test.ts\`: every mode, default mode, validation-failure path, auto_play behaviour, validate=false skip, init refusal, alias forwarding equivalence for all five, and the still-distinct get_pattern read path
- [x] \`tsc --noEmit\` clean
- [x] Full suite: 1644 pass, 20 skipped, 0 fail
- [x] \`npm run lint\` clean (0 errors, 136 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)