### PR TITLE
feat(#147): consolidate 8 transform ops → transform(op)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-72-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-73-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -197,7 +197,7 @@ Then ask Claude:
 
 <!-- TOOLS:START -->
 
-**72 tools** across 15 categories:
+**73 tools** across 15 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -264,7 +264,7 @@ Then ask Claude:
 | `generate_melody` | Generate melody from scale |
 | `generate_polyrhythm` | Generate polyrhythm |
 | `generate_fill` | Generate drum fill |
-| `generate_variation` | Create pattern variations |
+| `generate_variation` | [DEPRECATED — use transform({ op: "vary" }) instead] Create pattern variations (mis-named today; it transforms, not generates) |
 
 </details>
 
@@ -275,7 +275,7 @@ Then ask Claude:
 | `generate_scale` | Generate scale notes |
 | `generate_chord_progression` | Generate chord progression |
 | `generate_euclidean` | Generate Euclidean rhythm |
-| `apply_scale` | Apply scale to notes |
+| `apply_scale` | [DEPRECATED — use transform({ op: "scale" }) instead] Apply scale to notes |
 
 </details>
 
@@ -283,14 +283,14 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `transpose` | Transpose notes by semitones |
-| `reverse` | Reverse pattern |
-| `stretch` | Time stretch pattern |
-| `quantize` | Quantize to grid |
-| `humanize` | Add human timing variation |
+| `transpose` | [DEPRECATED — use transform({ op: "transpose" }) instead] Transpose notes by semitones |
+| `reverse` | [DEPRECATED — use transform({ op: "reverse" }) instead] Reverse pattern |
+| `stretch` | [DEPRECATED — use transform({ op: "stretch" }) instead] Time stretch pattern |
+| `quantize` | [DEPRECATED — use transform({ op: "quantize" }) instead] Quantize to grid |
+| `humanize` | [DEPRECATED — use transform({ op: "humanize" }) instead] Add human timing variation |
 | `add_effect` | Add effect to pattern |
 | `remove_effect` | Remove effect |
-| `add_swing` | Add swing to pattern |
+| `add_swing` | [DEPRECATED — use transform({ op: "swing" }) instead] Add swing to pattern |
 | `set_energy` | Adjust the overall energy level of the current pattern on a 0-10 scale. 0: minimal/ambient, 1-2: sparse, 3-4: light/relaxed, 5-6: normal/moderate, 7-8: driving/intense, 9-10: maximum. Auto-plays after applying energy level. |
 
 </details>
@@ -362,7 +362,7 @@ Then ask Claude:
 
 </details>
 
-<details><summary><strong>Other</strong> (7)</summary>
+<details><summary><strong>Other</strong> (8)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -373,10 +373,11 @@ Then ask Claude:
 | `transpile_pattern` | Transpile pattern source via StrudelEngine; returns transpiled code or syntax error |
 | `history` | Navigate or inspect the pattern edit history.  |
 | `pattern_store` | Persist patterns to disk and read them back.  |
+| `transform` | Apply a single transform op to the current session pattern.  |
 
 </details>
 
-_Auto-generated from source. 72 tools registered._
+_Auto-generated from source. 73 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/src/__tests__/unit/TransformConsolidation.test.ts
+++ b/src/__tests__/unit/TransformConsolidation.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the transform consolidation (#147).
+ *
+ * transform(op) replaces 8 transform verbs. Effects, mood/energy/refine,
+ * and set_tempo stay separate (Phase 3 / future).
+ */
+
+import { execute } from '../../server/tools/transform';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx() {
+  let pattern = 'note("c3")';
+  const generator = {
+    generateVariation: jest.fn((p: string, type: string) => `${p}.vary(${type})`),
+  };
+  const ctx: ToolContext = {
+    controller: {} as any,
+    perfMonitor: {} as any,
+    store: {} as any,
+    generator: generator as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => ({}) as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => true,
+    ensureInitialized: async () => {},
+    getController: () => ({ play: jest.fn() }) as any,
+    getCurrentPatternSafe: async () => pattern,
+    writePatternSafe: async (p: string) => { pattern = p; return 'written'; },
+  };
+  return { ctx, generator, pattern: () => pattern };
+}
+
+describe('transform consolidation (#147)', () => {
+  describe('transform(op)', () => {
+    it('op=transpose shifts notes', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'transpose', semitones: 7 }, ctx);
+      expect(pattern()).not.toBe('note("c3")');
+      // c3 + 7 = g3
+      expect(pattern()).toContain('g3');
+    });
+
+    it('op=transpose throws on non-integer semitones', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('transform', { op: 'transpose', semitones: 1.5 }, ctx))
+        .rejects.toThrow(/integer/);
+    });
+
+    it('op=reverse appends .rev', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'reverse' }, ctx);
+      expect(pattern()).toBe('note("c3").rev');
+    });
+
+    it('op=stretch appends .slow(factor)', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'stretch', factor: 2 }, ctx);
+      expect(pattern()).toContain('.slow(2)');
+    });
+
+    it('op=quantize appends .struct', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'quantize', grid: '1/16' }, ctx);
+      expect(pattern()).toContain('.struct("1/16")');
+    });
+
+    it('op=humanize appends .nudge', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'humanize', amount: 0.05 }, ctx);
+      expect(pattern()).toContain('.nudge');
+    });
+
+    it('op=swing appends .swing(amount)', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'swing', amount: 0.3 }, ctx);
+      expect(pattern()).toContain('.swing(0.3)');
+    });
+
+    it('op=scale appends .scale("root:scale")', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('transform', { op: 'scale', root: 'C', scale: 'minor' }, ctx);
+      expect(pattern()).toContain('.scale("C:minor")');
+    });
+
+    it('op=vary defers to PatternGenerator.generateVariation', async () => {
+      const { ctx, generator, pattern } = makeCtx();
+      await execute('transform', { op: 'vary', type: 'glitch' }, ctx);
+      expect(generator.generateVariation).toHaveBeenCalledWith('note("c3")', 'glitch');
+      expect(pattern()).toContain('.vary(glitch)');
+    });
+
+    it('op=vary defaults type to subtle', async () => {
+      const { ctx, generator } = makeCtx();
+      await execute('transform', { op: 'vary' }, ctx);
+      expect(generator.generateVariation).toHaveBeenCalledWith('note("c3")', 'subtle');
+    });
+
+    it('throws on invalid op', async () => {
+      const { ctx } = makeCtx();
+      await expect(execute('transform', { op: 'fold' }, ctx)).rejects.toThrow(/Invalid op/);
+    });
+  });
+
+  describe('legacy aliases forward (deprecation window)', () => {
+    it('transpose alias matches transform(op=transpose)', async () => {
+      const { ctx: a, pattern: pa } = makeCtx();
+      const { ctx: b, pattern: pb } = makeCtx();
+      await execute('transpose', { semitones: 5 }, a);
+      await execute('transform', { op: 'transpose', semitones: 5 }, b);
+      expect(pa()).toBe(pb());
+    });
+
+    it('reverse alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('reverse', {}, ctx);
+      expect(pattern()).toBe('note("c3").rev');
+    });
+
+    it('stretch alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('stretch', { factor: 0.5 }, ctx);
+      expect(pattern()).toContain('.slow(0.5)');
+    });
+
+    it('quantize alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('quantize', { grid: '1/8' }, ctx);
+      expect(pattern()).toContain('.struct("1/8")');
+    });
+
+    it('humanize alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('humanize', { amount: 0.02 }, ctx);
+      expect(pattern()).toContain('.nudge');
+    });
+
+    it('generate_variation alias matches transform(op=vary)', async () => {
+      const { ctx: a, pattern: pa } = makeCtx();
+      const { ctx: b, pattern: pb } = makeCtx();
+      await execute('generate_variation', { type: 'evolving' }, a);
+      await execute('transform', { op: 'vary', type: 'evolving' }, b);
+      expect(pa()).toBe(pb());
+    });
+
+    it('add_swing alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('add_swing', { amount: 0.4 }, ctx);
+      expect(pattern()).toContain('.swing(0.4)');
+    });
+
+    it('apply_scale alias forwards', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('apply_scale', { root: 'D', scale: 'dorian' }, ctx);
+      expect(pattern()).toContain('.scale("D:dorian")');
+    });
+  });
+
+  describe('untouched tools still work (separate consolidations)', () => {
+    it('add_effect still mutates as before', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('add_effect', { effect: 'reverb', params: '0.5' }, ctx);
+      expect(pattern()).toContain('.reverb(0.5)');
+    });
+
+    it('set_tempo still prepends setcpm', async () => {
+      const { ctx, pattern } = makeCtx();
+      await execute('set_tempo', { bpm: 140 }, ctx);
+      expect(pattern()).toContain('setcpm(140)');
+    });
+  });
+});

--- a/src/server/tools/transform.ts
+++ b/src/server/tools/transform.ts
@@ -83,8 +83,42 @@ const SESSION_ID_PROP = {
 
 export const tools: Tool[] = [
   {
+    name: 'transform',
+    description:
+      'Apply a single transform op to the current session pattern. ' +
+      'op=transpose shifts notes by `semitones`. ' +
+      'op=reverse appends `.rev` to the pattern. ' +
+      'op=stretch slows by `factor` (>1 slower, <1 faster). ' +
+      'op=quantize snaps to the `grid` (e.g. "1/16"). ' +
+      'op=humanize adds rand-nudge timing of `amount` (0-1). ' +
+      'op=swing applies `.swing(amount)` (alias for add_swing). ' +
+      'op=scale applies a `root`/`scale` filter to notes (alias for apply_scale). ' +
+      'op=vary returns a variation of `type` (subtle/moderate/extreme/glitch/evolving — note: this is what generate_variation does today; the name is misleading because it transforms rather than generates). ' +
+      'Example: transform({ op: "transpose", semitones: 7 }). ' +
+      'For effects (add/remove) use effect; for mood/energy/refine use shape; for tempo use set_tempo.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        op: {
+          type: 'string',
+          enum: ['transpose', 'reverse', 'stretch', 'quantize', 'humanize', 'swing', 'scale', 'vary'],
+          description: 'Which transform to apply',
+        },
+        semitones: { type: 'number', description: 'op=transpose: integer semitones to shift' },
+        factor: { type: 'number', description: 'op=stretch: stretch factor' },
+        grid: { type: 'string', description: 'op=quantize: grid size (e.g. "1/16")' },
+        amount: { type: 'number', description: 'op=humanize/swing: amount 0-1' },
+        root: { type: 'string', description: 'op=scale: root note (e.g. "C")' },
+        scale: { type: 'string', description: 'op=scale: scale name (e.g. "minor")' },
+        type: { type: 'string', description: 'op=vary: variation type (subtle/moderate/extreme/glitch/evolving)' },
+        ...SESSION_ID_PROP,
+      },
+      required: ['op'],
+    },
+  },
+  {
     name: 'transpose',
-    description: 'Transpose notes by semitones',
+    description: '[DEPRECATED — use transform({ op: "transpose" }) instead] Transpose notes by semitones',
     inputSchema: {
       type: 'object',
       properties: { semitones: { type: 'number', description: 'Semitones to transpose' }, ...SESSION_ID_PROP },
@@ -93,12 +127,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'reverse',
-    description: 'Reverse pattern',
+    description: '[DEPRECATED — use transform({ op: "reverse" }) instead] Reverse pattern',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'stretch',
-    description: 'Time stretch pattern',
+    description: '[DEPRECATED — use transform({ op: "stretch" }) instead] Time stretch pattern',
     inputSchema: {
       type: 'object',
       properties: { factor: { type: 'number', description: 'Stretch factor' }, ...SESSION_ID_PROP },
@@ -107,7 +141,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'quantize',
-    description: 'Quantize to grid',
+    description: '[DEPRECATED — use transform({ op: "quantize" }) instead] Quantize to grid',
     inputSchema: {
       type: 'object',
       properties: { grid: { type: 'string', description: 'Grid size (e.g., "1/16")' }, ...SESSION_ID_PROP },
@@ -116,7 +150,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'humanize',
-    description: 'Add human timing variation',
+    description: '[DEPRECATED — use transform({ op: "humanize" }) instead] Add human timing variation',
     inputSchema: {
       type: 'object',
       properties: { amount: { type: 'number', description: 'Humanization amount (0-1)' }, ...SESSION_ID_PROP },
@@ -124,7 +158,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'generate_variation',
-    description: 'Create pattern variations',
+    description: '[DEPRECATED — use transform({ op: "vary" }) instead] Create pattern variations (mis-named today; it transforms, not generates)',
     inputSchema: {
       type: 'object',
       properties: { type: { type: 'string', description: 'Variation type (subtle/moderate/extreme/glitch/evolving)' }, ...SESSION_ID_PROP },
@@ -163,7 +197,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'add_swing',
-    description: 'Add swing to pattern',
+    description: '[DEPRECATED — use transform({ op: "swing" }) instead] Add swing to pattern',
     inputSchema: {
       type: 'object',
       properties: { amount: { type: 'number', description: 'Swing amount (0-1)' }, ...SESSION_ID_PROP },
@@ -172,7 +206,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'apply_scale',
-    description: 'Apply scale to notes',
+    description: '[DEPRECATED — use transform({ op: "scale" }) instead] Apply scale to notes',
     inputSchema: {
       type: 'object',
       properties: {
@@ -223,55 +257,98 @@ export const tools: Tool[] = [
 
 export const toolNames = new Set(tools.map(t => t.name));
 
+// ---- per-op helpers (shared by transform({op}) and the deprecated aliases)
+
+async function opTranspose(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  if (typeof args.semitones !== 'number' || !Number.isInteger(args.semitones)) {
+    throw new Error('Semitones must be an integer');
+  }
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(transposePattern(p, args.semitones), sid);
+  return `Transposed ${args.semitones} semitones`;
+}
+
+async function opReverse(ctx: ToolContext, sid?: string): Promise<unknown> {
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(p + '.rev', sid);
+  return 'Pattern reversed';
+}
+
+async function opStretch(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateGain(args.factor);
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(p + `.slow(${args.factor})`, sid);
+  return `Stretched by factor of ${args.factor}`;
+}
+
+async function opQuantize(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.grid, 'grid', 50, false);
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(p + `.struct("${args.grid}")`, sid);
+  return `Quantized to ${args.grid} grid`;
+}
+
+async function opHumanize(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  if (args.amount !== undefined) InputValidator.validateNormalizedValue(args.amount, 'amount');
+  const p = await ctx.getCurrentPatternSafe(sid);
+  const amt = args.amount || 0.01;
+  await ctx.writePatternSafe(p + `.nudge(rand.range(-${amt}, ${amt}))`, sid);
+  return 'Added human timing';
+}
+
+async function opVary(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  const p = await ctx.getCurrentPatternSafe(sid);
+  const varied = ctx.generator.generateVariation(p, args.type || 'subtle');
+  await ctx.writePatternSafe(varied, sid);
+  return `Added ${args.type || 'subtle'} variation`;
+}
+
+async function opSwing(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateNormalizedValue(args.amount, 'amount');
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(p + `.swing(${args.amount})`, sid);
+  return `Added swing: ${args.amount}`;
+}
+
+async function opScale(args: any, ctx: ToolContext, sid?: string): Promise<unknown> {
+  InputValidator.validateStringLength(args.scale, 'scale', 50, false);
+  InputValidator.validateRootNote(args.root);
+  const p = await ctx.getCurrentPatternSafe(sid);
+  await ctx.writePatternSafe(p + `.scale("${args.root}:${args.scale}")`, sid);
+  return `Applied ${args.root} ${args.scale} scale`;
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
   if (!sid && !ctx.isInitialized()) {
     return 'Browser not initialized. Run init first.';
   }
   switch (name) {
-    case 'transpose': {
-      if (typeof args.semitones !== 'number' || !Number.isInteger(args.semitones)) {
-        throw new Error('Semitones must be an integer');
+    case 'transform': {
+      const op = args?.op;
+      switch (op) {
+        case 'transpose': return await opTranspose(args, ctx, sid);
+        case 'reverse':   return await opReverse(ctx, sid);
+        case 'stretch':   return await opStretch(args, ctx, sid);
+        case 'quantize':  return await opQuantize(args, ctx, sid);
+        case 'humanize':  return await opHumanize(args, ctx, sid);
+        case 'swing':     return await opSwing(args, ctx, sid);
+        case 'scale':     return await opScale(args, ctx, sid);
+        case 'vary':      return await opVary(args, ctx, sid);
+        default:
+          throw new Error(`Invalid op: ${op}. Must be one of: transpose, reverse, stretch, quantize, humanize, swing, scale, vary`);
       }
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(transposePattern(p, args.semitones), sid);
-      return `Transposed ${args.semitones} semitones`;
     }
 
-    case 'reverse': {
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(p + '.rev', sid);
-      return 'Pattern reversed';
-    }
-
-    case 'stretch': {
-      InputValidator.validateGain(args.factor);
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(p + `.slow(${args.factor})`, sid);
-      return `Stretched by factor of ${args.factor}`;
-    }
-
-    case 'quantize': {
-      InputValidator.validateStringLength(args.grid, 'grid', 50, false);
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(p + `.struct("${args.grid}")`, sid);
-      return `Quantized to ${args.grid} grid`;
-    }
-
-    case 'humanize': {
-      if (args.amount !== undefined) InputValidator.validateNormalizedValue(args.amount, 'amount');
-      const p = await ctx.getCurrentPatternSafe(sid);
-      const amt = args.amount || 0.01;
-      await ctx.writePatternSafe(p + `.nudge(rand.range(-${amt}, ${amt}))`, sid);
-      return 'Added human timing';
-    }
-
-    case 'generate_variation': {
-      const p = await ctx.getCurrentPatternSafe(sid);
-      const varied = ctx.generator.generateVariation(p, args.type || 'subtle');
-      await ctx.writePatternSafe(varied, sid);
-      return `Added ${args.type || 'subtle'} variation`;
-    }
+    // Deprecated aliases — forward to per-op helpers.
+    case 'transpose':          return await opTranspose(args, ctx, sid);
+    case 'reverse':            return await opReverse(ctx, sid);
+    case 'stretch':            return await opStretch(args, ctx, sid);
+    case 'quantize':           return await opQuantize(args, ctx, sid);
+    case 'humanize':           return await opHumanize(args, ctx, sid);
+    case 'generate_variation': return await opVary(args, ctx, sid);
+    case 'add_swing':          return await opSwing(args, ctx, sid);
+    case 'apply_scale':        return await opScale(args, ctx, sid);
 
     case 'add_effect': {
       InputValidator.validateStringLength(args.effect, 'effect', 100, false);
@@ -299,21 +376,6 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       const p = await ctx.getCurrentPatternSafe(sid);
       await ctx.writePatternSafe(`setcpm(${args.bpm})\n${p}`, sid);
       return `Set tempo to ${args.bpm} BPM`;
-    }
-
-    case 'add_swing': {
-      InputValidator.validateNormalizedValue(args.amount, 'amount');
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(p + `.swing(${args.amount})`, sid);
-      return `Added swing: ${args.amount}`;
-    }
-
-    case 'apply_scale': {
-      InputValidator.validateStringLength(args.scale, 'scale', 50, false);
-      InputValidator.validateRootNote(args.root);
-      const p = await ctx.getCurrentPatternSafe(sid);
-      await ctx.writePatternSafe(p + `.scale("${args.root}:${args.scale}")`, sid);
-      return `Applied ${args.root} ${args.scale} scale`;
     }
 
     case 'shift_mood':


### PR DESCRIPTION
Third Phase 2 installment and the **biggest single merger** in #120. Closes #147.

Eight verbs collapse into one \`transform(op)\` tool. Legacy verbs remain as deprecated aliases.

| op | Old equivalent | What it does |
|---|---|---|
| \`transpose\` | \`transpose\` | shifts notes by integer semitones |
| \`reverse\` | \`reverse\` | appends \`.rev\` |
| \`stretch\` | \`stretch\` | appends \`.slow(factor)\` |
| \`quantize\` | \`quantize\` | appends \`.struct(grid)\` |
| \`humanize\` | \`humanize\` | appends \`.nudge(rand-range)\` |
| \`swing\` | \`add_swing\` | appends \`.swing(amount)\` |
| \`scale\` | \`apply_scale\` | appends \`.scale("root:scale")\` |
| \`vary\` | \`generate_variation\` | runs PatternGenerator.generateVariation (mis-named today — it transforms) |

Each op extracted to a private function so the new tool and 8 alias paths share one source of truth.

## Out of scope (separate Phase 3 mergers)

- \`add_effect\`/\`remove_effect\` → \`effect\` (#153)
- \`shift_mood\`/\`set_energy\`/\`refine\` → \`shape\` (#154)
- \`set_tempo\` stays a distinct verb per the audit

## Test plan

- [x] 21 new cases in \`TransformConsolidation.test.ts\` — every op, alias forwarding for all 8, error on invalid op, default args (\`vary\` defaults type to \`subtle\`), sanity check untouched in-module tools (add_effect, set_tempo) still work
- [x] \`tsc --noEmit\` clean
- [x] Full suite: 1662 pass, 20 skipped, 0 fail
- [x] \`npm run lint\` clean (0 errors, 145 warnings)
- [x] \`npm run build\` regenerates README; drift test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)