### PR TITLE
feat(#155): consolidate audio capture tools → audio_capture(action)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-80-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-81-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -197,7 +197,7 @@ Then ask Claude:
 
 <!-- TOOLS:START -->
 
-**80 tools** across 15 categories:
+**81 tools** across 15 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -344,9 +344,9 @@ Then ask Claude:
 
 | Tool | Description |
 |------|-------------|
-| `start_audio_capture` | Start capturing audio from Strudel output. Audio must be playing for capture to work. |
-| `stop_audio_capture` | Stop audio capture and return the recorded audio as base64-encoded data. |
-| `capture_audio_sample` | Capture a fixed-duration audio sample from Strudel output. Audio must be playing. |
+| `start_audio_capture` | [DEPRECATED — use audio_capture({ action: "start" }) instead] Start capturing audio. Audio must be playing. |
+| `stop_audio_capture` | [DEPRECATED — use audio_capture({ action: "stop" }) instead] Stop audio capture and return base64-encoded audio. |
+| `capture_audio_sample` | [DEPRECATED — use audio_capture({ action: "sample" }) instead] Capture a fixed-duration audio sample. |
 
 </details>
 
@@ -362,7 +362,7 @@ Then ask Claude:
 
 </details>
 
-<details><summary><strong>Other</strong> (15)</summary>
+<details><summary><strong>Other</strong> (16)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -371,6 +371,7 @@ Then ask Claude:
 | `analyze_pattern_local` | Static analysis (events/cycle, complexity, optional BPM) without browser playback |
 | `query_pattern_events` | Enumerate events the pattern would emit between two cycle indices (max 16 cycles) |
 | `transpile_pattern` | Transpile pattern source via StrudelEngine; returns transpiled code or syntax error |
+| `audio_capture` | Record audio output from the live Strudel session.  |
 | `edit_pattern` | Mutate the current session pattern.  |
 | `generate_part` | Generate a single instrumental layer and append it to the current session pattern.  |
 | `music_theory` | Music-theory queries.  |
@@ -384,7 +385,7 @@ Then ask Claude:
 
 </details>
 
-_Auto-generated from source. 80 tools registered._
+_Auto-generated from source. 81 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/src/__tests__/unit/AudioCaptureConsolidation.test.ts
+++ b/src/__tests__/unit/AudioCaptureConsolidation.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the audio_capture consolidation (#155).
+ */
+
+import { execute } from '../../server/tools/capture';
+import type { ToolContext } from '../../server/tools/types';
+
+function makeCtx() {
+  const service = {
+    isCapturing: jest.fn(() => false),
+    startCapture: jest.fn(async () => undefined),
+    stopCapture: jest.fn(async () => ({
+      blob: { arrayBuffer: async () => new ArrayBuffer(8) },
+      duration: 3000,
+      format: 'webm',
+    })),
+    captureForDuration: jest.fn(async () => ({
+      blob: { arrayBuffer: async () => new ArrayBuffer(8) },
+      duration: 5000,
+      format: 'webm',
+    })),
+  };
+  const controller = { page: {} };
+  const ctx: ToolContext = {
+    controller: controller as any,
+    perfMonitor: {} as any, store: {} as any, generator: {} as any, theory: {} as any,
+    sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
+    midiExportService: {} as any,
+    getAudioCaptureService: async () => service as any,
+    history: { undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 },
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => true,
+    ensureInitialized: async () => {},
+    getController: () => controller as any,
+    getCurrentPatternSafe: async () => '',
+    writePatternSafe: async () => 'written',
+  };
+  return { ctx, service };
+}
+
+describe('audio_capture consolidation (#155)', () => {
+  it('audio_capture(action=start) starts a stream', async () => {
+    const { ctx, service } = makeCtx();
+    const result = (await execute('audio_capture', { action: 'start', format: 'webm' }, ctx)) as any;
+    expect(result.success).toBe(true);
+    expect(service.startCapture).toHaveBeenCalled();
+  });
+
+  it('audio_capture(action=stop) returns base64-encoded audio', async () => {
+    const { ctx, service } = makeCtx();
+    service.isCapturing.mockReturnValue(true);
+    const result = (await execute('audio_capture', { action: 'stop' }, ctx)) as any;
+    expect(result.success).toBe(true);
+    expect(typeof result.audio).toBe('string');
+  });
+
+  it('audio_capture(action=sample) captures a fixed-duration window', async () => {
+    const { ctx, service } = makeCtx();
+    await execute('audio_capture', { action: 'sample', duration: 3000 }, ctx);
+    expect(service.captureForDuration).toHaveBeenCalledWith(expect.anything(), 3000);
+  });
+
+  it('audio_capture(action=sample) defaults duration to 5000ms', async () => {
+    const { ctx, service } = makeCtx();
+    await execute('audio_capture', { action: 'sample' }, ctx);
+    expect(service.captureForDuration).toHaveBeenCalledWith(expect.anything(), 5000);
+  });
+
+  it('audio_capture(action=sample) rejects out-of-range duration', async () => {
+    const { ctx } = makeCtx();
+    const result = (await execute('audio_capture', { action: 'sample', duration: 50 }, ctx)) as any;
+    expect(result.success).toBe(false);
+  });
+
+  it('throws on invalid action', async () => {
+    const { ctx } = makeCtx();
+    await expect(execute('audio_capture', { action: 'pause' }, ctx)).rejects.toThrow(/Invalid action/);
+  });
+
+  describe('legacy aliases forward', () => {
+    it('start_audio_capture alias forwards', async () => {
+      const { ctx, service } = makeCtx();
+      await execute('start_audio_capture', {}, ctx);
+      expect(service.startCapture).toHaveBeenCalled();
+    });
+
+    it('capture_audio_sample alias forwards', async () => {
+      const { ctx, service } = makeCtx();
+      await execute('capture_audio_sample', { duration: 2000 }, ctx);
+      expect(service.captureForDuration).toHaveBeenCalledWith(expect.anything(), 2000);
+    });
+
+    it('stop_audio_capture alias forwards', async () => {
+      const { ctx, service } = makeCtx();
+      service.isCapturing.mockReturnValue(true);
+      const result = (await execute('stop_audio_capture', {}, ctx)) as any;
+      expect(result.success).toBe(true);
+    });
+  });
+
+  it('export_midi stays distinct (separate verb per audit)', async () => {
+    const { ctx } = makeCtx();
+    // No MIDI service is meaningfully wired in this test — just confirm the
+    // case routes through and returns a structured object rather than throwing.
+    const ctxWithMidi = { ...ctx, midiExportService: { exportToBase64: jest.fn(() => ({ success: false, error: 'no notes', output: '', noteCount: 0, bars: 4, bpm: 120 })) } } as any;
+    const result = (await execute('export_midi', {}, ctxWithMidi)) as any;
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/server/tools/capture.ts
+++ b/src/server/tools/capture.ts
@@ -39,8 +39,31 @@ const SESSION_ID_PROP = {
 
 export const tools: Tool[] = [
   {
+    name: 'audio_capture',
+    description:
+      'Record audio output from the live Strudel session. ' +
+      'action=start begins streaming capture (optional `format` webm/opus, default webm). ' +
+      'action=stop ends the stream and returns base64-encoded audio. ' +
+      'action=sample captures a fixed-`duration` window in one call (100-60000ms, default 5000ms). ' +
+      'Example: audio_capture({ action: "sample", duration: 3000 }). ' +
+      'Audio must be playing for capture to record meaningful data. ' +
+      'For MIDI export use export_midi; for runtime diagnostics use diagnostics. ' +
+      'Note: the AudioCaptureService is currently a server-wide singleton — concurrent captures across sessions will conflict.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['start', 'stop', 'sample'], description: 'Capture action' },
+        format: { type: 'string', enum: ['webm', 'opus'], description: 'action=start: audio format (default webm)' },
+        maxDuration: { type: 'number', description: 'action=start: maximum capture duration ms' },
+        duration: { type: 'number', description: 'action=sample: duration ms (100-60000, default 5000)' },
+        ...SESSION_ID_PROP,
+      },
+      required: ['action'],
+    },
+  },
+  {
     name: 'start_audio_capture',
-    description: 'Start capturing audio from Strudel output. Audio must be playing for capture to work.',
+    description: '[DEPRECATED — use audio_capture({ action: "start" }) instead] Start capturing audio. Audio must be playing.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -52,12 +75,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'stop_audio_capture',
-    description: 'Stop audio capture and return the recorded audio as base64-encoded data.',
+    description: '[DEPRECATED — use audio_capture({ action: "stop" }) instead] Stop audio capture and return base64-encoded audio.',
     inputSchema: { type: 'object', properties: { ...SESSION_ID_PROP } },
   },
   {
     name: 'capture_audio_sample',
-    description: 'Capture a fixed-duration audio sample from Strudel output. Audio must be playing.',
+    description: '[DEPRECATED — use audio_capture({ action: "sample" }) instead] Capture a fixed-duration audio sample.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -90,6 +113,17 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
   // produces a structured { success: false, message } from any error,
   // including AudioCaptureService's "Browser not initialized" throw.
   switch (name) {
+    case 'audio_capture': {
+      const a = args?.action;
+      switch (a) {
+        case 'start':  return await startAudioCapture(args?.format, args?.maxDuration, ctx, sid);
+        case 'stop':   return await stopAudioCapture(ctx, sid);
+        case 'sample': return await captureAudioSample(args?.duration, ctx, sid);
+        default:
+          throw new Error(`Invalid action: ${a}. Must be one of: start, stop, sample`);
+      }
+    }
+
     case 'start_audio_capture':
       return await startAudioCapture(args?.format, args?.maxDuration, ctx, sid);
 


### PR DESCRIPTION
Closes #155. 3 verbs → 1 tool, export_midi stays separate per audit. 10 new tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)