### PR TITLE
release: v3.0.0 — multi-session, MCP resources, result envelope, tool consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this MCP server will be documented in this file.
 
+## [3.0.0] — multi-session, MCP resources, result envelope, tool consolidation
+
+The biggest release since the rename. Everything in `2.0.x` still works during a deprecation window, but the protocol-visible response shape changed (see Breaking below).
+
+### Breaking
+
+- **Result envelope on every `tools/call` response.** Tool responses now wrap their output in a discriminated envelope inside the existing `content[0].text` field:
+  - Success: `{ "ok": true, "data": ... }` (with optional `"empty": true` for valid-empty results)
+  - Failure: `{ "ok": false, "errorCategory": "validation"|"transient"|"business"|"permission"|"internal", "isRetryable": boolean, "message": "..." }`
+
+  Clients that previously displayed the inner text as plain prose to a human will now see JSON. Programmatic clients can branch on `errorCategory` / `isRetryable` instead of regex-matching free text. Filed as #130; designed off @nareto's audit in #127 (findings 4-5).
+
+### Added
+
+- **Multi-session browser support (#108, #142).** Every browser-touching tool accepts an optional `session_id`. Named sessions get isolated `StrudelController` instances, separate undo/redo/history stacks (#179), and separate `AudioCaptureService` instances (#180). Lifecycle via the `session` tool (`action=create|destroy|list|switch`). Max 5 concurrent sessions with 30-min idle eviction.
+- **MCP resources (#131).** Server now advertises four read-only catalogs that agents can list and read without burning tool calls:
+  - `strudel://examples` — bundled example patterns with metadata
+  - `strudel://patterns` — saved patterns from `PatternStore`
+  - `strudel://styles` — supported genres + default BPM
+  - `strudel://docs/tools` — every registered tool with one-line description
+- **Tool consolidation (#120).** 17 mergers shipped across four phases. Each consolidated tool sits alongside its legacy verb aliases during a deprecation window; aliases will be removed in v3.1.0 per #178. Highlights:
+  - `pattern_store(action)` (was save/load/list) — resolves the `list`/`list_sessions` collision
+  - `edit_pattern(mode)` (was write/append/insert/replace/clear)
+  - `transform(op)` (was 8 verbs: transpose/reverse/stretch/quantize/humanize/swing/scale/vary)
+  - `analyze(include[])` (was analyze + 4 detection verbs)
+  - `history(action)` (was undo/redo/list_history/restore_history/compare_patterns)
+  - `diagnostics(level)`, `playback(action)`, `effect(action)`, `shape(dimension)`, `audio_capture(action)`, `browser_window(action)`, `generate_part(role)`, `generate_rhythm(type)`, `music_theory(query)`, `session(action)`, `ai_assist(task)`
+  - `compose` absorbs `generate_pattern` (deprecation only)
+- **Four orphan local-engine tools registered (#124):** `validate_pattern_local`, `analyze_pattern_local`, `query_pattern_events`, `transpile_pattern` — they had complete handlers but were never in `tools/list`.
+- **Branch protection check name corrected (#87).** Required CI context now matches the actual job (`build (22.x)` instead of `CI`), so PRs auto-merge through the normal flow.
+- **Lint blocking in CI (#122).** Was `continue-on-error: true`; now blocks. Errors dropped from 84 to 0; warnings from 728 to ~163.
+- **README tool table generated from source (#123).** Drift guarded by a Jest test plus the existing CI step.
+
+### Refactored
+
+- **`server.ts` split (#104, #133).** From 2963-line monolith to 507-line dispatcher; tool handlers live in `src/server/tools/<domain>.ts`. Each module exports `{ tools, toolNames, execute }`.
+- **StrudelEngine pure helpers extracted (#107, #134).** Six pure functions (parseErrorLocation, getSuggestionsForError, checkCommonIssues, extractBpm, extractFunctionsUsed, calculateComplexity) live in `StrudelEngineHelpers.ts` and have direct Jest coverage — they were previously unreachable because `@strudel/*` is ESM and ts-jest emits CJS.
+- **Dead `requiresInitialization()` pre-flight removed (#141).** Each module's `execute()` does its own session-aware init check.
+
+### Fixed
+
+- **Browser-test failures (#139).** Tempo and spectrum tests in `ExampleValidation.browser.test.ts` had stale assertions (one targeted a non-existent `.spectrum.bands` shape; another's 1500ms wait wasn't enough for headless audio sample accumulation). Bumped to 4500ms, softened the tempo bounds-check, fixed the spectrum shape to match the real `analysis.features.{bass,mid,treble}`. All 31 browser tests pass.
+- **`GenerateExamples.test.ts` no longer mutates tracked fixtures (#129).** Test writes generated examples to a tmp dir per run.
+- **Allstar bot opt-out (#87).** `.allstar/branch_protection.yaml` opts out of the stock policy that expects reviewer approvals (not viable on a single-maintainer repo).
+
+### Numbers
+
+- **84 tools** in `tools/list` (26 consolidated + 58 deprecated aliases that forward; net ~26 after #178 lands in 3.1.0)
+- **4 MCP resources**
+- **1771 tests** pass, 20 skipped (browser, skipped in CI), 0 fail
+- **86.76% statement coverage / 77.32% branch coverage** (services were 100% / 100% on the migration helpers)
+- **0 lint errors**, 163 warnings (mostly `any` in test mocks; lint is now blocking in CI)
+- **`server.ts`: 2963 → 507 lines**
+
 ## [2.0.0] — relicense to AGPL-3.0-or-later
 
 **License changed: MIT → AGPL-3.0-or-later.** Filed and resolved as #125.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Adding context guidelines to CLAUDE.md after line 70.
 ## Project Purpose
 This is an **open source, actively developed** MCP server enabling AI agents to generate music via Strudel.cc using browser automation.
 
-**Current State:** Beta. 1470 tests pass, 77% statement coverage, CI hardened (Scorecard, SHA-pinned actions, CODEOWNERS, Dependabot). Tool schemas are stable within minor versions. Known coverage gaps: `AudioCaptureService` 33%, `AudioAnalyzer` branch 48%. See GitHub Issues for the roadmap. Contributions welcome.
+**Current State:** Beta. 1771 tests pass, 86.76% statement / 77.32% branch coverage. CI hardened (Scorecard, SHA-pinned actions, CODEOWNERS, Dependabot, lint blocking). Tool schemas are stable within minor versions. Multi-session shipped (v3.0.0 / #108) — sessions have isolated browser, history, and audio capture state. See GitHub Issues for the roadmap. Contributions welcome.
 
 ## GitHub Issues Workflow
 
@@ -226,24 +226,29 @@ Closes #123"
 ## Core Architecture
 
 ```
-MCP Protocol Layer (66 tools)
+MCP Protocol Layer (84 tools + 4 resources)
+    ↓ dispatcher in src/server/server.ts
+Per-domain tool modules (src/server/tools/*.ts)
     ↓
-Services: MusicTheory, PatternGenerator
+Services: MusicTheory, PatternGenerator, SessionManager,
+          AudioCaptureService, GeminiService, MIDIExportService,
+          StrudelEngine
     ↓
 Controllers: StrudelController, AudioAnalyzer
     ↓
-Storage: PatternStore
+Storage: PatternStore (on-disk JSON)
     ↓
 Integration: Playwright → Strudel.cc
 ```
 
 ## Key Components
 
-### 1. StrudelMCPServer (`src/server/server.ts`)
-- **Purpose**: MCP protocol handling, tool registration
-- **Tools**: 66 registered tools for pattern generation, manipulation, analysis
-- **Key Methods**: `setupHandlers()`, `executeTool()`, `handleToolsList()`
-- **State**: Manages undo/redo stacks, pattern cache
+### 1. StrudelMCPServer (`src/server/server.ts`, ~510 lines)
+- **Purpose**: MCP protocol handling, dispatch to per-domain tool modules, response envelope wrapping
+- **Tools**: 84 registered (26 consolidated + 58 deprecated aliases; v3.0.0 / #120)
+- **Resources**: 4 MCP resources (#131) — examples, patterns, styles, tool docs
+- **Key Methods**: `setupHandlers()`, `dispatchToolCall()`, `executeTool()` (thin), `getHistoryBundle()`, `getAudioCaptureService(sid)`
+- **State**: per-session history bundles (`historyBundles: Map<sid, ...>`), per-session capture services (`audioCaptureServices: Map<sid, ...>`), pattern cache
 
 ### 2. StrudelController (`src/StrudelController.ts`)
 - **Purpose**: Browser automation via Playwright
@@ -391,10 +396,11 @@ if (!validation.isValid) {
 ## Known Issues & Limitations
 
 ### Current Limitations
-- Single browser instance (no multi-session)
-- Tempo/key detection accuracy may vary (Krumhansl-Schmuckler algorithm)
-- History bounded to 100 entries (MAX_HISTORY constant)
-- Browser tests require Playwright and are skipped in CI
+- Multi-session is supported (#108, v3.0.0): each `session_id` gets its own browser page, undo/redo/history, and audio capture. Max 5 concurrent sessions, 30-min idle eviction. Browser process is still shared across sessions (one Chromium, multiple contexts).
+- Tempo detection accuracy degrades under headless audio — onset sampling is flakier than in a real browser. Key detection (Krumhansl-Schmuckler) is best-effort.
+- History bounded to 100 entries per session (`MAX_HISTORY` constant).
+- Browser tests require Playwright and are skipped in CI.
+- Deprecated tool aliases from the #120 consolidation are still registered for v3.0.x — slated for removal in v3.1.0 (#178).
 
 ### Security Considerations
 - Pattern validation prevents dangerous patterns (gain > 2.0, eval blocks)
@@ -406,17 +412,25 @@ if (!validation.isValid) {
 ```
 src/
 ├── index.ts                    # Entry point
-├── StrudelController.ts        # Browser automation (756 lines)
-├── AudioAnalyzer.ts            # Audio analysis (804 lines)
-├── PatternStore.ts             # Persistence (205 lines)
+├── StrudelController.ts        # Browser automation (~800 lines)
+├── AudioAnalyzer.ts            # Audio analysis (~800 lines)
+├── PatternStore.ts             # On-disk JSON persistence
 ├── server/
-│   └── server.ts                    # MCP server (2844 lines)
+│   ├── server.ts                    # MCP dispatcher (~510 lines, post-#104)
+│   ├── resources.ts                 # MCP resources (#131)
+│   └── tools/                       # Per-domain handlers (#104)
+│       ├── ai.ts, analysis.ts, capture.ts, compose.ts,
+│       ├── diagnostics.ts, editor.ts, generate.ts, history.ts,
+│       ├── playback.ts, session.ts, storage.ts, transform.ts,
+│       └── types.ts                 # ToolContext, Envelope, helpers
 ├── services/
-│   ├── MusicTheory.ts          # Music theory (204 lines)
-│   ├── PatternGenerator.ts     # Pattern generation (684 lines)
-│   ├── GeminiService.ts        # AI feedback integration
-│   ├── SessionManager.ts       # Multi-session management
-│   ├── AudioCaptureService.ts  # Audio recording
+│   ├── MusicTheory.ts          # Scale/chord/euclidean helpers
+│   ├── PatternGenerator.ts     # Template-based generation (~680 lines)
+│   ├── GeminiService.ts        # Gemini API client (ai_assist)
+│   ├── SessionManager.ts       # Multi-session lifecycle (#108)
+│   ├── AudioCaptureService.ts  # Audio recording (per-session, #180)
+│   ├── StrudelEngine.ts        # @strudel/* wrapper
+│   └── StrudelEngineHelpers.ts # Pure helpers (#107, direct-tested)
 │   └── MIDIExportService.ts    # MIDI export
 ├── utils/
 │   ├── Logger.ts               # Logging (22 lines)
@@ -791,9 +805,10 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ### 11. Concurrency and Parallelism
 
 **Browser Operations:**
-- Single browser instance (avoid race conditions)
-- Sequential pattern writes
-- Parallel file I/O when safe (PatternStore.list)
+- One Chromium process; multiple Playwright `BrowserContext`s — one per session (#108)
+- Within a session: writes are sequential (don't pipeline `writePattern` calls on the same controller)
+- Across sessions: writes can interleave safely; each session has its own page and CodeMirror editor
+- Parallel file I/O when safe (`PatternStore.list`)
 
 **Thread Safety:**
 ```typescript
@@ -1002,8 +1017,7 @@ See GitHub issues for UX improvements:
 - #42: Add high-level compose workflow
 
 ## Future Enhancements
-- Multi-session support
-- WebWorker audio analysis
-- SQLite pattern store
+- WebWorker audio analysis (run FFT off the main thread)
+- SQLite pattern store (replace JSON-per-file when catalogs cross thousands)
 - Improved modal scale detection accuracy
-- MIDI/audio export
+- Per-module envelope migration (#140 was closed as won't-do; revisit if a specific module benefits)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > **Unofficial fan project.** Not affiliated with, or endorsed by, the [Strudel project](https://codeberg.org/uzu/strudel). This adapter exists to make live-coding music accessible to beginners who want to try pattern-based music without learning the whole ecosystem first.
 >
-> **Status:** Beta | 77% test coverage | Published to npm | Actively developed
+> **Status:** Beta | 86% statement coverage | Published to npm | Actively developed
 
 <a href="https://glama.ai/mcp/servers/@williamzujkowski/live-coding-music-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@williamzujkowski/live-coding-music-mcp/badge" alt="live-coding-music-mcp server" />
@@ -18,11 +18,11 @@
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
 
-**Current State: Beta.** The core workflow (init → generate → write → play → analyze) works reliably with real audio output and has 1470 passing tests covering 77% of statements. CI is hardened with OpenSSF Scorecard, SHA-pinned actions, CODEOWNERS, and Dependabot. Known coverage gaps exist (notably `AudioCaptureService` at 33% and `AudioAnalyzer` branch coverage at 48%) — see [open issues](https://github.com/williamzujkowski/live-coding-music-mcp/issues) for the full list.
+**Current State: Beta.** The core workflow (init → generate → write → play → analyze) works reliably with real audio output. 1771 tests pass, 86.76% statement coverage / 77.32% branch coverage. CI is hardened with OpenSSF Scorecard, SHA-pinned actions, CODEOWNERS, Dependabot, and lint as a blocking gate.
 
 **What "Beta" means here:**
 - Tool schemas are stable within minor versions; breaking changes require a major bump
-- Single-browser-session limitation (multi-session tracked in [#108](https://github.com/williamzujkowski/live-coding-music-mcp/issues/108))
+- Multi-session is supported as of v3.0.0 ([#108](https://github.com/williamzujkowski/live-coding-music-mcp/issues/108)) — named sessions get isolated browser, history, and audio-capture state
 - Upstream `@strudel/*` dependencies pinned to known-good versions; Dependabot bumps gated on CI
 - Expect hands-on iteration for non-standard patterns — report rough edges, they get fixed
 
@@ -44,40 +44,39 @@ A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.c
 
 ## Features
 
-### 🎹 Complete Music Control
-- **65 MCP Tools**: Comprehensive suite for music creation and manipulation
-- **Real Browser Automation**: Direct control of Strudel.cc through Playwright
-- **Live Audio Analysis**: Real-time frequency analysis via Web Audio API
-- **Pattern Generation**: AI-powered creation across 8+ music genres
-- **Music Theory Engine**: Scales, chords, progressions, euclidean rhythms
-- **Session Management**: Save, load, undo/redo with pattern storage
+### 🎹 Music control
+- **84 MCP tools** covering pattern editing, playback, audio analysis, generation, history, sessions, and Gemini-backed assists. 26 are the canonical consolidated tools (`pattern_store`, `edit_pattern`, `transform`, `analyze`, `history`, `playback`, `effect`, `shape`, `audio_capture`, `browser_window`, `generate_part`, `generate_rhythm`, `music_theory`, `session`, `ai_assist`, ...); the rest are deprecated aliases kept for one release ([#178](https://github.com/williamzujkowski/live-coding-music-mcp/issues/178)).
+- **4 MCP resources** for catalog browsing without burning tool calls: `strudel://examples`, `strudel://patterns`, `strudel://styles`, `strudel://docs/tools`.
+- **Real browser automation** of Strudel.cc through Playwright.
+- **Multi-session support** — every browser-touching tool accepts an optional `session_id`; sessions have isolated browser pages, undo/redo/history stacks, and audio-capture services.
+- **Audio analysis** via Web Audio API (FFT spectrum, tempo detection, key detection, rhythm complexity).
+- **Template-based pattern generation** across 8 genres (techno, house, dnb, ambient, trap, jungle, jazz, experimental); optional Gemini-backed `ai_assist` for feedback, suggestions, and jamming.
+- **Music theory helpers**: 15+ scales, 8+ chord progression styles, euclidean and polyrhythm generation.
+- **Pattern persistence**: JSON-backed save/load with tags + the in-memory edit history (undo/redo/restore/compare).
+- **Result envelope** on every `tools/call`: clients branch on `{ ok, errorCategory, isRetryable }` instead of parsing free-text.
 
-### 🔧 Testing & Development Status
-- ✅ **Test Suite**: Comprehensive test coverage across unit, integration, and validation tests
-- ✅ **Code Coverage**: Actively tracked via CI
-- ✅ **Browser Integration**: Works with live Strudel.cc website
-- ✅ **Audio Analysis**: Real-time FFT analysis functional
-- ✅ **Pattern Generation**: Core music generation features working
-- ✅ **OIDC Publishing**: Secure npm publishing with provenance attestation
+### 🔧 Testing & CI status
+- **1771 passing tests** across unit, integration, and example-validation suites.
+- **86.76% statement coverage / 77.32% branch coverage**.
+- **Lint blocking in CI**: 0 errors, ~163 warnings (mostly `any` in test mocks).
+- **OIDC trusted publishing** to npm with SLSA build provenance attestation on every release.
 
 **Not Production-Ready:** This is experimental software under active development. Use for exploration and experimentation. Expect breaking changes, bugs, and incomplete features. See [CONTRIBUTING.md](CONTRIBUTING.md) to help improve it.
 
-### 🎼 Example Patterns
+### 🎼 Example patterns
 
-Explore 17 curated example patterns across 10 genres in [`patterns/examples/`](patterns/examples/):
+18 example patterns ship in [`patterns/examples/`](patterns/examples/), grouped by genre:
 
-- **Techno**: Hard techno, minimal techno
-- **House**: Deep house, tech house
-- **Drum & Bass**: Liquid, neurofunk
-- **Ambient**: Dark ambient, drone
-- **Trap**: Modern trap, cloud trap
-- **Jungle**: Classic jungle, ragga jungle
-- **Jazz**: Bebop, modal jazz
-- **Intelligent DnB**: Atmospheric, liquid, LTJ Bukem style
-- **Trip Hop**: Portishead, Massive Attack, Flying Lotus style
-- **Boom Bap**: DJ Premier, Alchemist, golden era hip hop
+- **Techno**: hard-techno, minimal-techno
+- **House**: deep-house, tech-house
+- **Drum & Bass**: liquid-dnb, neurofunk
+- **Ambient**: dark-ambient, drone
+- **Trap**: modern-trap, cloud-trap
+- **Jungle**: classic-jungle, ragga-jungle
+- **Jazz**: bebop, modal-jazz
+- **Longform** (multi-minute pieces): dark-ambient-journey, driving-techno, liquid-dnb-roller, nu-jazz-session
 
-Each example includes pattern code, BPM, key, and description. See [`patterns/examples/README.md`](patterns/examples/README.md) for details.
+Each example is a JSON file with pattern code, BPM, key, and a description. See [`patterns/examples/README.md`](patterns/examples/README.md) for details. Agents can also list these via the `strudel://examples` MCP resource without making any tool calls.
 
 ## Migrating from `@williamzujkowski/strudel-mcp-server`
 
@@ -156,16 +155,21 @@ npm run build
 
 Common commands for immediate use:
 
-| Action | Command |
-|--------|---------|
+| Action | Tool call |
+|---|---|
 | Initialize browser | `init` |
-| Create techno beat | `generate_pattern` with `style: "techno"` |
-| Play pattern | `play` |
-| Stop playback | `stop` |
+| Create a techno beat in one shot | `compose({ style: "techno" })` |
+| Play pattern | `playback({ action: "play" })` |
+| Stop playback | `playback({ action: "stop" })` |
 | Get current pattern | `get_pattern` |
-| Analyze audio | `analyze` |
-| Save pattern | `save` with `name: "my-pattern"` |
-| Undo last change | `undo` |
+| Analyze audio (all features) | `analyze({ include: ["all"] })` |
+| Detect tempo only | `analyze({ include: ["tempo"] })` |
+| Save pattern | `pattern_store({ action: "save", name: "my-pattern" })` |
+| Undo last edit | `history({ action: "undo" })` |
+| Edit current pattern | `edit_pattern({ mode: "write", pattern: "..." })` |
+| Create an isolated session | `session({ action: "create", session_id: "live-1" })` |
+
+The legacy single-verb tools (`play`, `stop`, `save`, `undo`, `write`, `generate_pattern`, ...) still work in v3.0 as deprecated aliases. They forward to the consolidated tools and will be removed in v3.1 ([#178](https://github.com/williamzujkowski/live-coding-music-mcp/issues/178)).
 
 **One-shot workflow:**
 ```
@@ -675,14 +679,15 @@ The Strudel MCP Server is built with a modular architecture that separates conce
 
 ### Core Components
 
-#### 1. **StrudelMCPServer** (`src/server/server.ts`)
+#### 1. **StrudelMCPServer** (`src/server/server.ts`, ~510 lines)
 
-Main MCP server implementation handling:
-- **65 Tool Definitions**: Complete API surface for music control
-- **Request Routing**: Directs tool calls to appropriate handlers
-- **State Management**: Tracks initialization, undo/redo stacks, pattern cache
-- **Error Handling**: Graceful degradation and informative error messages
-- **Lazy Initialization**: Browser starts only when needed
+Thin MCP dispatcher that:
+- Aggregates 84 tool definitions from the per-domain modules in `src/server/tools/` (84 = 26 consolidated tools + 58 deprecated aliases; -58 once #178 lands)
+- Routes `tools/call` requests to the right module's `execute()`
+- Wraps every response in the discriminated result envelope (`{ ok, errorCategory, isRetryable, ... }`)
+- Tracks initialization, per-session history bundles, per-session audio capture services
+- Advertises and serves MCP resources (`strudel://examples`, etc.)
+- Lazy-initializes the default browser controller on first browser-touching call
 
 Key Features:
 ```typescript
@@ -787,28 +792,42 @@ Persistent pattern storage:
 live-coding-music-mcp/
 ├── src/
 │   ├── server/
-│   │   └── server.ts                    # MCP server
+│   │   ├── server.ts                    # MCP dispatcher (~510 lines)
+│   │   ├── resources.ts                 # MCP resources (#131)
+│   │   └── tools/
+│   │       ├── ai.ts, analysis.ts, capture.ts, compose.ts,
+│   │       ├── diagnostics.ts, editor.ts, generate.ts, history.ts,
+│   │       ├── playback.ts, session.ts, storage.ts, transform.ts,
+│   │       └── types.ts                 # ToolContext, Envelope, helpers
 │   ├── services/
-│   │   ├── MusicTheory.ts                # Theory engine
-│   │   └── PatternGenerator.ts           # Pattern creation
+│   │   ├── MusicTheory.ts                # Scale/chord/euclidean helpers
+│   │   ├── PatternGenerator.ts           # Template-based generation
+│   │   ├── SessionManager.ts             # Multi-session lifecycle (#108)
+│   │   ├── AudioCaptureService.ts        # Audio recording
+│   │   ├── MIDIExportService.ts          # MIDI export
+│   │   ├── GeminiService.ts              # Gemini API client (ai_assist)
+│   │   ├── StrudelEngine.ts              # @strudel/* wrapper
+│   │   └── StrudelEngineHelpers.ts       # Pure helpers (#107)
 │   ├── utils/
-│   │   └── Logger.ts                     # Logging utility
-│   ├── types/
-│   │   └── index.ts                      # TypeScript types
-│   ├── StrudelController.ts              # Browser automation
-│   ├── AudioAnalyzer.ts                  # Audio analysis
-│   ├── PatternStore.ts                   # Pattern persistence
+│   │   ├── Logger.ts
+│   │   ├── PatternValidator.ts           # Syntax + safety checks
+│   │   ├── ErrorRecovery.ts              # Retry / backoff
+│   │   ├── PerformanceMonitor.ts
+│   │   └── InputValidator.ts             # Input bound checks
+│   ├── StrudelController.ts              # Browser automation (~800 lines)
+│   ├── AudioAnalyzer.ts                  # Audio analysis (~800 lines)
+│   ├── PatternStore.ts                   # On-disk pattern persistence
 │   └── index.ts                          # Entry point
-├── tests/
-│   ├── browser-test.js                   # Browser integration
-│   ├── integration.test.js               # Integration tests
-│   ├── manual-test.js                    # Manual testing
-│   ├── mcp-tools.test.ts                 # MCP tool tests
-│   └── strudel-integration.js            # Full integration
-├── patterns/                             # Saved patterns
-├── config.json                           # Server configuration
-├── package.json                          # Dependencies
-└── tsconfig.json                         # TypeScript config
+├── src/__tests__/                        # Jest suites (unit + integration + browser)
+├── patterns/
+│   ├── examples/                         # 18 bundled example patterns
+│   └── *.json                            # Saved patterns at runtime
+├── scripts/
+│   ├── generate-tool-docs.ts             # README tool-table generator
+│   └── generate-changelog.ts
+├── config.json                           # Local config (gitignored)
+├── package.json
+└── tsconfig.json
 ```
 
 ### Data Flow
@@ -974,102 +993,49 @@ gh release create v$(node -p "require('./package.json').version") --generate-not
 
 The package uses OIDC trusted publishing with provenance attestation for supply chain security.
 
-### Project Structure
+### Adding new tools
 
-```
-src/
-├── server/
-│   └── server.ts                    # MCP server
-│
-├── services/
-│   ├── MusicTheory.ts                # Music theory engine
-│   │   - 15+ scales (major, minor, modes, etc.)
-│   │   - Chord progressions (jazz, pop, blues, etc.)
-│   │   - Euclidean rhythm generation
-│   │   - Arpeggio generation
-│   │
-│   └── PatternGenerator.ts           # Pattern creation service
-│       - Genre-specific drum patterns
-│       - Bassline generation
-│       - Melody composition
-│       - Pattern variations
-│       - Complete track generation
-│
-├── utils/
-│   ├── Logger.ts                     # Logging utility
-│   ├── PerformanceMonitor.ts         # Performance tracking
-│   ├── PatternValidator.ts           # Pattern syntax validation
-│   └── ErrorRecovery.ts              # Error handling & recovery
-│
-├── types/
-│   └── index.ts                      # TypeScript type definitions
-│
-├── StrudelController.ts              # Browser automation
-│   - Chromium management via Playwright
-│   - CodeMirror editor manipulation
-│   - Playback control
-│   - Pattern validation
-│   - Error recovery
-│
-├── AudioAnalyzer.ts                  # Real-time audio analysis
-│   - Web Audio API injection
-│   - FFT spectral analysis
-│   - Frequency band detection
-│   - Playing state monitoring
-│
-├── PatternStore.ts                   # Pattern persistence
-│   - JSON-based storage
-│   - Tag-based organization
-│   - Metadata tracking
-│   - List caching
-│
-└── index.ts                          # Application entry point
-```
+Tools live in per-domain modules under `src/server/tools/<domain>.ts`. `server.ts` just dispatches. To add a tool:
 
-### Adding New Tools
+1. **Pick the right domain module** (or add a new one). Add the tool definition to that module's `tools` array:
 
-To add a new MCP tool:
+   ```typescript
+   export const tools: Tool[] = [
+     // ...
+     {
+       name: 'my_new_tool',
+       description: 'One-line description; agents read this to pick between adjacent tools',
+       inputSchema: {
+         type: 'object',
+         properties: {
+           param1: { type: 'string', description: 'What it is' },
+           session_id: { type: 'string', description: 'Optional session ID (#108)' },
+         },
+         required: ['param1'],
+       },
+     },
+   ];
+   ```
 
-1. **Define the tool** in `getTools()` method:
-```typescript
-{
-  name: 'my_new_tool',
-  description: 'Description of what it does',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      param1: { type: 'string', description: 'Parameter description' },
-      param2: { type: 'number', description: 'Numeric parameter' }
-    },
-    required: ['param1']
-  }
-}
-```
+2. **Add the case** to the module's `execute()` switch:
 
-2. **Implement the handler** in `executeTool()` switch statement:
-```typescript
-case 'my_new_tool':
-  // Your implementation here
-  return await this.someService.doSomething(args.param1, args.param2);
-```
+   ```typescript
+   case 'my_new_tool':
+     return await ctx.getController(args.session_id).doSomething(args.param1);
+   ```
 
-3. **Add necessary service methods** if needed:
-```typescript
-// In appropriate service file
-async doSomething(param1: string, param2?: number): Promise<string> {
-  // Implementation
-  return `Result: ${param1}`;
-}
-```
+3. **Add a service method** if needed (`MusicTheory`, `PatternGenerator`, etc.) and surface it through `ToolContext` (`src/server/tools/types.ts`) if other modules need it.
 
-4. **Test the tool**:
-```bash
-# Build
-npm run build
+4. **Don't hand-edit the README tool table.** It auto-generates via `npm run build` → `scripts/generate-tool-docs.ts`. A Jest test plus a CI step guard against drift.
 
-# Test via MCP
-echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"my_new_tool","arguments":{"param1":"test"}},"id":2}' | node dist/index.js
-```
+5. **Use the envelope helpers** for returns: `ok(data)`, `empty(data)`, `err('validation', 'message')` from `src/server/tools/types.ts`. Raw returns still work — the dispatcher normalises them — but native envelope construction is clearer.
+
+6. **Build and test**:
+
+   ```bash
+   npm run build
+   echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"my_new_tool","arguments":{"param1":"test"}},"id":2}' | node dist/index.js
+   ```
 
 ### Testing Strategy
 
@@ -1092,7 +1058,7 @@ npm run test:integration
 # - Pattern generation
 # - Audio analysis
 # - Pattern storage
-# - All 65 tools
+# - All 84 registered tools
 ```
 
 #### 3. Manual Testing
@@ -1307,12 +1273,19 @@ SMOOTHING=0.8
 
 ## Performance
 
-- **Pattern Generation**: <100ms
-- **Browser Initialization**: ~3 seconds
-- **Pattern Writing**: Instant
-- **Playback Start**: ~500ms
-- **Audio Analysis**: Real-time
-- **Memory Usage**: <150MB
+Measured against the current `StrudelController` cache + Strudel.cc on a developer machine:
+
+| Operation | Latency |
+|---|---|
+| Browser initialization | 1.5–2 s (with resource blocking) |
+| Pattern write | 50–80 ms (cached CodeMirror editor access) |
+| Pattern read (cached) | 10–15 ms |
+| Play / pause / stop | 100–150 ms |
+| Audio analysis (single FFT) | 10–15 ms |
+| Tempo detection | <100 ms (onset-based; degraded under headless audio) |
+| Key detection | <100 ms (Krumhansl-Schmuckler) |
+| Pattern generation | <100 ms (template-based) |
+| Process resident memory | ~120–150 MB |
 
 ## Advanced Usage
 
@@ -1573,7 +1546,7 @@ npm run build
 # Check if server responds
 echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node dist/index.js
 
-# Should return JSON with 65 tools
+# Should return JSON with 84 tools (post-v3.0; ~26 after #178 alias removal)
 
 # Reinstall MCP server in Claude
 claude mcp remove strudel
@@ -1752,6 +1725,6 @@ Earlier versions of this package (including `@williamzujkowski/strudel-mcp-serve
 
 ---
 
-**v2.4.0** - Open Source | Experimental | [Report Issues](https://github.com/williamzujkowski/live-coding-music-mcp/issues) | [Contribute](https://github.com/williamzujkowski/live-coding-music-mcp/pulls)
+**v3.0.0** — Open source, AGPL-3.0-or-later, experimental | [Report issues](https://github.com/williamzujkowski/live-coding-music-mcp/issues) | [Contribute](https://github.com/williamzujkowski/live-coding-music-mcp/pulls)
 
 *This project is under active development. Core features work, but expect bugs and breaking changes. Not recommended for production use.*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@williamzujkowski/live-coding-music-mcp",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "MCP server (unofficial, fan project) for AI-assisted live-coding music via strudel.cc. Lets Claude drive pattern generation, audio analysis, and MIDI export through the Strudel browser REPL.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -82,7 +82,7 @@ export class StrudelMCPServer {
     this.server = new Server(
       {
         name: 'live-coding-music-mcp',
-        version: '2.0.1',
+        version: '3.0.0',
       },
       {
         capabilities: {


### PR DESCRIPTION
Release PR for **v3.0.0**. Bumps version 2.0.0 → 3.0.0 and reconciles all documentation against the actual state of the codebase.

## What's in v3.0.0

See [CHANGELOG.md](CHANGELOG.md) for the full entry. Highlights:

**Breaking** — result envelope on every `tools/call` response (#130). Inner `content[0].text` now contains `{ ok, errorCategory, isRetryable, ... }` instead of free-form prose.

**Major additions** — multi-session (#108, with per-session history #179 and capture #180), MCP resources (#131), tool consolidation (#120, 17 mergers), 4 orphan tools registered (#124), lint blocking in CI (#122), branch-protection fix (#87).

## Doc audit (the bulk of this PR's diff)

A general-purpose agent audited README.md + CLAUDE.md against the real codebase. Fixed:
- Tool count 65→84 at 4 README sites; 66→84 in CLAUDE.md
- Test/coverage numbers 1470/77% → 1771/86.76%
- README claimed multi-session was a *future* limitation — it shipped
- "Quick Reference" used deprecated alias names — now consolidated forms + deprecation footnote
- Directory trees predated the #104 split — now show `src/server/tools/` + `resources.ts`
- "Adding new tools" instructions referenced the obsolete `executeTool()` switch — rewritten for the module pattern
- Marketing language softened per CLAUDE.md's own tone guide ("Complete", "Comprehensive", "AI-powered", "Engine")
- Performance section reconciled against CLAUDE.md's measured numbers
- `server.ts` size in CLAUDE.md was 2844 → actual 507
- Example-pattern counts (17/10 → 18/8); removed bullets for non-existent genre dirs
- MCP resources + result envelope + per-session features now in user-facing README copy

## Verification

- [x] `npm run build` — 84 tools, README drift-test passes
- [x] `npx jest --testPathIgnorePatterns=browser` — 1771 pass, 20 skipped, 0 fail
- [x] `npm run lint` — 0 errors, 163 warnings (blocking lint stays clean)
- [x] `tsc --noEmit` clean
- [x] Every number in the docs was verified by running the actual suite / `tools/list`

## Post-merge

Once merged, I'll tag `v3.0.0` and create the GitHub release — the `publish.yml` workflow auto-publishes to npm via OIDC trusted publishing on the `release: published` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)