### PR TITLE
fix(ci): use corepack for npm upgrade in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,19 +39,26 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure we have npm 11.5.1+ for OIDC trusted publishing
-      - name: Update npm to latest
-        run: npm install -g npm@latest
+      # OIDC trusted publishing needs npm >= 11.5.1. The runner's bundled
+      # npm (10.x with Node 22) is too old, but `npm install -g npm@latest`
+      # self-corrupts mid-upgrade (MODULE_NOT_FOUND: promise-retry) because
+      # the old npm can't rebuild the new npm's dependency tree. Corepack
+      # manages the install out-of-band and sidesteps that entirely.
+      - name: Pin npm >= 11.5.1 via corepack (for OIDC trusted publishing)
+        run: |
+          corepack enable
+          corepack install -g npm@latest
+          npm --version
 
       - name: Verify npm version
         run: |
           NPM_VERSION=$(npm --version)
           echo "npm version: $NPM_VERSION"
-          # Check if version is >= 11.5.1
           if [ "$(printf '%s\n' "11.5.1" "$NPM_VERSION" | sort -V | head -n1)" = "11.5.1" ]; then
             echo "npm version is sufficient for OIDC trusted publishing"
           else
-            echo "Warning: npm version may be too old for OIDC trusted publishing"
+            echo "::error::npm $NPM_VERSION is below the 11.5.1 required for OIDC trusted publishing"
+            exit 1
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
The v3.0.0 publish workflow failed on `npm install -g npm@latest` with `MODULE_NOT_FOUND: promise-retry` — the known npm self-corruption bug. Corepack manages the install out-of-band and avoids it. Also hardened the version check to fail the job instead of warning-and-continuing. Once merged, the v3.0.0 tag + release will be recreated from the fixed HEAD. 🤖 Generated with [Claude Code](https://claude.com/claude-code)