### PR TITLE
fix(ci): glob for tarball in publish workflow instead of parsing npm output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,12 +84,19 @@ jobs:
           # Keep it as fallback for transition period
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Pack the tarball so we can attest + attach it to the GitHub release
+      # Pack the tarball so we can attest + attach it to the GitHub release.
+      # `npm pack` runs the `prepare` hook (npm run build), whose generator
+      # script prints to stdout — so parsing npm's output (even --json) is
+      # fragile. Instead, just glob for the .tgz it produces: npm pack
+      # creates exactly one, named deterministically from package.json.
       - name: Pack tarball for attestation
         id: pack
         run: |
-          TARBALL=$(npm pack --silent)
-          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+          rm -f ./*.tgz
+          npm pack >/dev/null 2>&1
+          TARBALL=$(ls -1 ./*.tgz | head -n1)
+          test -n "${TARBALL}" && test -f "${TARBALL}" || { echo "::error::npm pack produced no .tgz"; exit 1; }
+          echo "tarball=${TARBALL#./}" >> "$GITHUB_OUTPUT"
           echo "Packed: ${TARBALL}"
 
       # GitHub-native SLSA build provenance on the published tarball —


### PR DESCRIPTION
Follow-up to #186. v3.0.0 published to npm successfully (with `npm publish --provenance`), but the post-publish SBOM + GitHub-native attestation steps failed: `npm pack` runs the `prepare` hook whose generate-tool-docs script prints to stdout, corrupting `$TARBALL`. Fix globs for the `.tgz` instead of parsing npm output. v3.0.0's SBOMs + tarball were backfilled to the release manually; future releases get the full pipeline. 🤖 Generated with [Claude Code](https://claude.com/claude-code)