### PR TITLE
Wire config.audio_analysis through to AudioAnalyzer (#195)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -204,4 +204,9 @@ PATTERNS_DIR=./patterns      # override pattern storage location
 HEADLESS=true                # used by test:browser script
 ```
 
-The `audio_analysis` config block (`fft_size`, `smoothing`) is currently **not wired** — the code hardcodes `fftSize = 1024`. Tracked in #195.
+The `audio_analysis` config block in `config.json` is wired to `AudioAnalyzer` (#195):
+
+- `fft_size`: power of 2 in [32, 32768]. Default 1024.
+- `smoothing`: number in [0, 1]. Default 0.8.
+
+Invalid values fall back to defaults with a warning rather than throwing — bad config in a hand-edited `config.json` shouldn't crash the server. Frequency-band boundaries inside `AudioAnalyzer.analyze()` scale automatically with `fftSize`, so changing FFT size preserves the Hz range each band covers (just at higher or lower resolution).

--- a/README.md
+++ b/README.md
@@ -612,11 +612,13 @@ node tests/strudel-integration.js
   "strudel_url": "https://strudel.cc/",
   "patterns_dir": "./patterns",
   "audio_analysis": {
-    "fft_size": 1024,
-    "smoothing": 0.8
+    "fft_size": 1024,       // power of 2 in [32, 32768]; default 1024
+    "smoothing": 0.8        // number in [0, 1]; default 0.8
   }
 }
 ```
+
+`audio_analysis.fft_size` tunes the FFT bin count on the `AnalyserNode` attached to Strudel's audio graph — larger = better frequency resolution at higher CPU cost. `smoothing` is the analyser's `smoothingTimeConstant` (higher = steadier spectrum, more lag). Invalid values fall back to defaults with a warning; the frequency-band boundaries inside `analyze` rescale automatically so band Hz coverage stays consistent across FFT sizes.
 
 ## Architecture
 

--- a/src/AudioAnalyzer.ts
+++ b/src/AudioAnalyzer.ts
@@ -4,8 +4,29 @@ import {
   KeyAnalysis,
   RhythmAnalysis,
   AdvancedAudioAnalysis,
-  AudioAnalysisResult
+  AudioAnalysisResult,
+  AudioAnalysisConfig,
 } from './types/AudioAnalysis.js';
+import { Logger } from './utils/Logger.js';
+
+const DEFAULT_FFT_SIZE = 1024;
+const DEFAULT_SMOOTHING = 0.8;
+const MIN_FFT_SIZE = 32;
+const MAX_FFT_SIZE = 32768;
+
+/**
+ * True if `n` is a power of two within the Web Audio AnalyserNode range
+ * (32-32768). Web Audio rejects anything else with an InvalidStateError.
+ */
+function isValidFftSize(n: unknown): n is number {
+  return (
+    typeof n === 'number' &&
+    Number.isInteger(n) &&
+    n >= MIN_FFT_SIZE &&
+    n <= MAX_FFT_SIZE &&
+    (n & (n - 1)) === 0
+  );
+}
 
 export class AudioAnalyzer {
   private _analysisCache: AudioAnalysisResult | null = null;
@@ -19,6 +40,11 @@ export class AudioAnalyzer {
   private _chromaHistory: number[][] = [];
   private readonly ONSET_THRESHOLD = 0.3;
   private readonly MAX_HISTORY_LENGTH = 100;
+
+  // Per-instance analyser config (wired through from config.audio_analysis
+  // in config.json). #195.
+  private readonly fftSize: number;
+  private readonly smoothing: number;
 
   // Pitch classes for key detection
   private readonly PITCH_CLASSES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
@@ -35,12 +61,58 @@ export class AudioAnalyzer {
   }
 
   /**
+   * @param options.fftSize - power of 2 in [32, 32768]. Default 1024.
+   * @param options.smoothing - value in [0, 1]. Default 0.8.
+   *
+   * Invalid values fall back to defaults with a warning rather than
+   * throwing; bad config in `config.json` shouldn't crash the server.
+   */
+  constructor(options?: AudioAnalysisConfig) {
+    const logger = new Logger();
+
+    if (options?.fftSize !== undefined && !isValidFftSize(options.fftSize)) {
+      logger.warn(
+        `AudioAnalyzer: invalid fftSize ${String(options.fftSize)} — must be a power of 2 in [${MIN_FFT_SIZE}, ${MAX_FFT_SIZE}]. Falling back to ${DEFAULT_FFT_SIZE}.`,
+      );
+      this.fftSize = DEFAULT_FFT_SIZE;
+    } else {
+      this.fftSize = options?.fftSize ?? DEFAULT_FFT_SIZE;
+    }
+
+    if (
+      options?.smoothing !== undefined &&
+      (typeof options.smoothing !== 'number' ||
+        Number.isNaN(options.smoothing) ||
+        options.smoothing < 0 ||
+        options.smoothing > 1)
+    ) {
+      logger.warn(
+        `AudioAnalyzer: invalid smoothing ${String(options.smoothing)} — must be in [0, 1]. Falling back to ${DEFAULT_SMOOTHING}.`,
+      );
+      this.smoothing = DEFAULT_SMOOTHING;
+    } else {
+      this.smoothing = options?.smoothing ?? DEFAULT_SMOOTHING;
+    }
+  }
+
+  /** Configured FFT size (read-only). Test/debug helper. */
+  getFftSize(): number {
+    return this.fftSize;
+  }
+
+  /** Configured smoothing constant (read-only). Test/debug helper. */
+  getSmoothing(): number {
+    return this.smoothing;
+  }
+
+  /**
    * Injects audio analysis code into the Strudel page
    * @param page - Playwright page instance to inject into
    */
   async inject(page: Page) {
+    const cfg = { fftSize: this.fftSize, smoothing: this.smoothing };
     /* istanbul ignore next -- browser-injected IIFE, covered by integration tests */
-    await page.evaluate(() => {
+    await page.evaluate((cfg: { fftSize: number; smoothing: number }) => {
       (window as any).strudelAudioAnalyzer = {
         analyser: null as AnalyserNode | null,
         dataArray: null as Uint8Array | null,
@@ -63,9 +135,9 @@ export class AudioAnalyzer {
 
               const ctx = args[0].context as AudioContext;
               (window as any).strudelAudioAnalyzer.analyser = ctx.createAnalyser();
-              // Reduced FFT size for better performance
-              (window as any).strudelAudioAnalyzer.analyser.fftSize = 1024;
-              (window as any).strudelAudioAnalyzer.analyser.smoothingTimeConstant = 0.8;
+              // Configurable via config.audio_analysis in config.json (#195).
+              (window as any).strudelAudioAnalyzer.analyser.fftSize = cfg.fftSize;
+              (window as any).strudelAudioAnalyzer.analyser.smoothingTimeConstant = cfg.smoothing;
               (window as any).strudelAudioAnalyzer.dataArray = new Uint8Array(
                 (window as any).strudelAudioAnalyzer.analyser.frequencyBinCount
               );
@@ -100,6 +172,18 @@ export class AudioAnalyzer {
           const dataArray = this.dataArray;
           const length = dataArray.length;
 
+          // Frequency-band boundaries scaled to the actual `length`.
+          // Reference values are bin indices that worked at fftSize=1024
+          // (length=512): bass<4, lowMid<16, mid<64, highMid<128,
+          // treble<256. Scaling by `length / 512` keeps each band over
+          // the same Hz range when fftSize changes (#195).
+          const scale = length / 512;
+          const bassEnd = Math.max(1, Math.round(4 * scale));
+          const lowMidEnd = Math.max(bassEnd + 1, Math.round(16 * scale));
+          const midEnd = Math.max(lowMidEnd + 1, Math.round(64 * scale));
+          const highMidEnd = Math.max(midEnd + 1, Math.round(128 * scale));
+          const trebleEnd = Math.max(highMidEnd + 1, Math.round(256 * scale));
+
           // Single-pass computation for better performance
           let sum = 0;
           let peak = 0;
@@ -119,23 +203,26 @@ export class AudioAnalyzer {
               peakIndex = i;
             }
 
-            // Frequency bands (adjusted for 1024 FFT)
-            if (i < 4) bassSum += value;
-            else if (i < 16) lowMidSum += value;
-            else if (i < 64) midSum += value;
-            else if (i < 128) highMidSum += value;
-            else if (i < 256) trebleSum += value;
+            // Frequency-band boundaries are derived from the bin indices
+            // that worked well at fftSize=1024 (length=512): 4, 16, 64,
+            // 128, 256. Scaling by `length / 512` preserves the Hz-range
+            // each band covers when fftSize changes (#195).
+            if (i < bassEnd) bassSum += value;
+            else if (i < lowMidEnd) lowMidSum += value;
+            else if (i < midEnd) midSum += value;
+            else if (i < highMidEnd) highMidSum += value;
+            else if (i < trebleEnd) trebleSum += value;
           }
 
           const average = sum / length;
           const centroid = sum > 0 ? weightedSum / sum : 0;
           const peakFreq = (peakIndex / length) * 22050;
 
-          const bass = bassSum / 4;
-          const lowMid = lowMidSum / 12;
-          const mid = midSum / 48;
-          const highMid = highMidSum / 64;
-          const treble = trebleSum / 128;
+          const bass = bassSum / Math.max(1, bassEnd);
+          const lowMid = lowMidSum / Math.max(1, lowMidEnd - bassEnd);
+          const mid = midSum / Math.max(1, midEnd - lowMidEnd);
+          const highMid = highMidSum / Math.max(1, highMidEnd - midEnd);
+          const treble = trebleSum / Math.max(1, trebleEnd - highMidEnd);
 
           const result = {
             connected: true,
@@ -169,7 +256,7 @@ export class AudioAnalyzer {
       };
       
       (window as any).strudelAudioAnalyzer.connect();
-    });
+    }, cfg);
   }
 
   /**

--- a/src/StrudelController.ts
+++ b/src/StrudelController.ts
@@ -34,9 +34,12 @@ export class StrudelController {
   private consoleErrors: string[] = [];
   private consoleWarnings: string[] = [];
 
-  constructor(headless: boolean = false) {
+  constructor(
+    headless: boolean = false,
+    audioAnalysisConfig?: import('./types/AudioAnalysis.js').AudioAnalysisConfig,
+  ) {
     this.isHeadless = headless;
-    this.analyzer = new AudioAnalyzer();
+    this.analyzer = new AudioAnalyzer(audioAnalysisConfig);
     this.validator = new PatternValidator();
     this.errorRecovery = new ErrorRecovery();
     this.logger = new Logger();

--- a/src/__tests__/unit/AudioAnalyzerConfig.test.ts
+++ b/src/__tests__/unit/AudioAnalyzerConfig.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for AudioAnalyzer constructor + config validation (#195).
+ *
+ * Covers the part of the analyzer that can be tested without a browser:
+ * config plumbing, validation, fallback behavior. The injected
+ * browser-side IIFE is `istanbul ignore next`'d and covered by browser
+ * integration tests.
+ */
+
+import { AudioAnalyzer } from '../../AudioAnalyzer';
+
+describe('AudioAnalyzer config', () => {
+  describe('defaults', () => {
+    it('uses fftSize 1024 and smoothing 0.8 when no options are passed', () => {
+      const a = new AudioAnalyzer();
+      expect(a.getFftSize()).toBe(1024);
+      expect(a.getSmoothing()).toBe(0.8);
+    });
+
+    it('uses defaults when an empty options object is passed', () => {
+      const a = new AudioAnalyzer({});
+      expect(a.getFftSize()).toBe(1024);
+      expect(a.getSmoothing()).toBe(0.8);
+    });
+  });
+
+  describe('valid options', () => {
+    it.each([32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768])(
+      'accepts power-of-2 fftSize %i',
+      (fftSize) => {
+        const a = new AudioAnalyzer({ fftSize });
+        expect(a.getFftSize()).toBe(fftSize);
+      },
+    );
+
+    it.each([0, 0.25, 0.5, 0.8, 0.95, 1])('accepts smoothing %f', (smoothing) => {
+      const a = new AudioAnalyzer({ smoothing });
+      expect(a.getSmoothing()).toBe(smoothing);
+    });
+
+    it('accepts both options together', () => {
+      const a = new AudioAnalyzer({ fftSize: 2048, smoothing: 0.5 });
+      expect(a.getFftSize()).toBe(2048);
+      expect(a.getSmoothing()).toBe(0.5);
+    });
+  });
+
+  describe('invalid fftSize falls back to 1024', () => {
+    it.each([
+      ['non-power-of-2', 1000],
+      ['below minimum (16)', 16],
+      ['above maximum (65536)', 65536],
+      ['zero', 0],
+      ['negative', -1024],
+      ['non-integer (1024.5)', 1024.5],
+    ])('rejects %s and falls back to 1024', (_label, fftSize) => {
+      const a = new AudioAnalyzer({ fftSize: fftSize as number });
+      expect(a.getFftSize()).toBe(1024);
+    });
+
+    it.each(['1024', null, NaN])('rejects non-number value %p and falls back to 1024', (badValue) => {
+      const a = new AudioAnalyzer({ fftSize: badValue as unknown as number });
+      expect(a.getFftSize()).toBe(1024);
+    });
+  });
+
+  describe('invalid smoothing falls back to 0.8', () => {
+    it.each([
+      ['negative', -0.1],
+      ['above 1', 1.1],
+      ['large negative', -5],
+      ['large positive', 100],
+    ])('rejects %s and falls back to 0.8', (_label, smoothing) => {
+      const a = new AudioAnalyzer({ smoothing });
+      expect(a.getSmoothing()).toBe(0.8);
+    });
+
+    it.each(['0.5', null, NaN])('rejects non-number value %p and falls back to 0.8', (badValue) => {
+      const a = new AudioAnalyzer({ smoothing: badValue as unknown as number });
+      expect(a.getSmoothing()).toBe(0.8);
+    });
+  });
+
+  describe('partial / mixed options', () => {
+    it('keeps default fftSize when only smoothing is set', () => {
+      const a = new AudioAnalyzer({ smoothing: 0.3 });
+      expect(a.getFftSize()).toBe(1024);
+      expect(a.getSmoothing()).toBe(0.3);
+    });
+
+    it('keeps default smoothing when only fftSize is set', () => {
+      const a = new AudioAnalyzer({ fftSize: 4096 });
+      expect(a.getFftSize()).toBe(4096);
+      expect(a.getSmoothing()).toBe(0.8);
+    });
+
+    it('falls back on each invalid field independently', () => {
+      const a = new AudioAnalyzer({ fftSize: 999, smoothing: 0.5 });
+      expect(a.getFftSize()).toBe(1024);  // invalid → default
+      expect(a.getSmoothing()).toBe(0.5); // valid → kept
+    });
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,6 +41,18 @@ const config = existsSync(configPath)
   ? JSON.parse(readFileSync(configPath, 'utf-8'))
   : { headless: false };
 
+// Translate config.audio_analysis (snake_case in JSON) to the camelCase
+// AudioAnalysisConfig the analyzer expects. Invalid values are normalized
+// to undefined here so the analyzer falls back to its own defaults
+// without a downstream warning for a value the user never set. (#195)
+const audioAnalysisConfig: { fftSize?: number; smoothing?: number } | undefined =
+  config.audio_analysis
+    ? {
+        fftSize: typeof config.audio_analysis.fft_size === 'number' ? config.audio_analysis.fft_size : undefined,
+        smoothing: typeof config.audio_analysis.smoothing === 'number' ? config.audio_analysis.smoothing : undefined,
+      }
+    : undefined;
+
 export class StrudelMCPServer {
   private server: Server;
   private controller: StrudelController;
@@ -92,13 +104,13 @@ export class StrudelMCPServer {
       }
     );
 
-    this.controller = new StrudelController(config.headless);
+    this.controller = new StrudelController(config.headless, audioAnalysisConfig);
     this.store = new PatternStore('./patterns');
     this.theory = new MusicTheory();
     this.generator = new PatternGenerator();
     this.geminiService = new GeminiService();
     this.midiExportService = new MIDIExportService();
-    this.sessionManager = new SessionManager(config.headless);
+    this.sessionManager = new SessionManager(config.headless, audioAnalysisConfig);
     this.logger = new Logger();
     this.perfMonitor = new PerformanceMonitor();
     this.strudelEngine = new StrudelEngine();

--- a/src/services/SessionManager.ts
+++ b/src/services/SessionManager.ts
@@ -1,6 +1,7 @@
 import { chromium, Browser, BrowserContext, Page } from 'playwright';
 import { StrudelController } from '../StrudelController.js';
 import { Logger } from '../utils/Logger.js';
+import type { AudioAnalysisConfig } from '../types/AudioAnalysis.js';
 
 /**
  * Session metadata including creation time and last activity
@@ -45,9 +46,11 @@ export class SessionManager {
   private readonly CLEANUP_INTERVAL = 5 * 60 * 1000;
 
   private cleanupTimer: NodeJS.Timeout | null = null;
+  private audioAnalysisConfig?: AudioAnalysisConfig;
 
-  constructor(headless: boolean = false) {
+  constructor(headless: boolean = false, audioAnalysisConfig?: AudioAnalysisConfig) {
     this.isHeadless = headless;
+    this.audioAnalysisConfig = audioAnalysisConfig;
     this.logger = new Logger();
   }
 
@@ -113,7 +116,7 @@ export class SessionManager {
     const page = await context.newPage();
 
     // Create controller with injected page (using a factory pattern)
-    const controller = new StrudelController(this.isHeadless);
+    const controller = new StrudelController(this.isHeadless, this.audioAnalysisConfig);
 
     // Initialize the controller with the existing page
     await this.initializeControllerWithPage(controller, page);

--- a/src/types/AudioAnalysis.ts
+++ b/src/types/AudioAnalysis.ts
@@ -61,6 +61,26 @@ export interface AudioAnalysisResult {
 }
 
 /**
+ * Runtime configuration for the AnalyserNode that AudioAnalyzer attaches
+ * to Strudel's audio graph. Maps to `config.audio_analysis` in config.json
+ * (snake_case there → camelCase here).
+ */
+export interface AudioAnalysisConfig {
+  /**
+   * FFT bin count. Must be a power of 2 in [32, 32768] per the Web Audio
+   * spec (https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/fftSize).
+   * Larger = better frequency resolution, more CPU per analysis call.
+   * Default: 1024 (~21 Hz/bin at 44.1 kHz, ~12 ms per analyse call).
+   */
+  fftSize?: number;
+  /**
+   * Smoothing time constant for the analyser. Must be in [0, 1]. Higher
+   * smooths the spectrum more (steadier, but laggier). Default: 0.8.
+   */
+  smoothing?: number;
+}
+
+/**
  * Pattern statistics
  */
 export interface PatternStats {


### PR DESCRIPTION
## Summary

The `audio_analysis` block in `config.json` (\`fft_size\`, \`smoothing\`) was dead config — \`server.ts\` only read \`headless\`, and \`AudioAnalyzer\` hardcoded \`fftSize = 1024\` / \`smoothingTimeConstant = 0.8\` in its browser-injected IIFE. Editing the values in \`config.json\` did literally nothing. This PR wires it up.

## Changes

- **New \`AudioAnalysisConfig\` interface** in \`types/AudioAnalysis.ts\` (camelCase TS; server.ts translates from the snake_case JSON).
- **AudioAnalyzer constructor** now accepts \`{ fftSize?, smoothing? }\` with validation:
  - \`fftSize\`: power of 2 in [32, 32768] (Web Audio spec). Default 1024.
  - \`smoothing\`: number in [0, 1]. Default 0.8.
  - Invalid values warn-and-fall-back; bad hand-edited config shouldn't crash the server.
- **\`inject(page)\`** passes the config into the \`page.evaluate\` payload as its second argument so the AnalyserNode actually picks up the real values.
- **Frequency-band boundaries** in the analyze loop (previously hardcoded \`if (i < 4)\`, \`if (i < 16)\`, ...) now scale proportionally to \`dataArray.length / 512\`. This preserves the Hz range each band covers when fftSize changes — bin index 8 at fftSize=2048 covers the same Hz as bin 4 at fftSize=1024.
- **\`StrudelController\` + \`SessionManager\`** constructors take an optional config arg and forward it so per-session controllers see the same settings.
- **\`server.ts\`** reads \`config.audio_analysis\`, normalizes snake_case → camelCase, drops malformed entries (so the analyzer falls back silently instead of warning on a key the user never set), passes the result through.

## Docs

- \`DEVELOPMENT.md\`: the \"not wired (#195)\" note is replaced by the actual config contract.
- \`README.md\` config.json example documents valid value ranges inline.

## Tests

39 new unit tests in \`AudioAnalyzerConfig.test.ts\`:
- Defaults (no options / empty options)
- All 11 valid power-of-2 fftSize values
- Boundary smoothing values (0, 0.25, 0.5, 0.8, 0.95, 1)
- Invalid fftSize fallback: non-power-of-2, below min, above max, zero, negative, non-integer, non-number, NaN
- Invalid smoothing fallback: negative, >1, non-number, NaN
- Mixed valid/invalid options handled independently

**Full suite: 1748 pass / 0 fail / 20 skipped (browser).** Up from 1709 baseline.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint src\` — 0 errors
- [x] Full Jest suite — 1748 pass / 0 fail
- [x] New \`AudioAnalyzerConfig.test.ts\` — 39 tests pass
- [x] Existing \`AudioAnalyzer.test.ts\` and other suites still pass (no regressions from threading the optional arg)
- [ ] CI green

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)