### PR TITLE
feat: MIDI→Strudel import (Phase 1: literal transcription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-26-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-27-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -45,7 +45,7 @@ A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.c
 ## Features
 
 ### 🎹 Music control
-- **26 MCP tools** covering pattern editing, playback, audio analysis, generation, history, sessions, and Gemini-backed assists. Each tool is enum-parameterized to keep the protocol surface small: `pattern_store({ action })`, `edit_pattern({ mode })`, `transform({ op })`, `analyze({ include })`, `history({ action })`, `playback({ action })`, `effect({ action })`, `shape({ dimension })`, `audio_capture({ action })`, `browser_window({ action })`, `generate_part({ role })`, `generate_rhythm({ type })`, `music_theory({ query })`, `session({ action })`, `ai_assist({ task })`, ... The 58 legacy single-verb aliases that forwarded to these were removed in v4.0.0 ([#178](https://github.com/williamzujkowski/live-coding-music-mcp/issues/178)).
+- **27 MCP tools** covering pattern editing, playback, audio analysis, generation, history, sessions, MIDI import/export, and Gemini-backed assists. Each tool is enum-parameterized to keep the protocol surface small: `pattern_store({ action })`, `edit_pattern({ mode })`, `transform({ op })`, `analyze({ include })`, `history({ action })`, `playback({ action })`, `effect({ action })`, `shape({ dimension })`, `audio_capture({ action })`, `browser_window({ action })`, `generate_part({ role })`, `generate_rhythm({ type })`, `music_theory({ query })`, `session({ action })`, `ai_assist({ task })`, ... The 58 legacy single-verb aliases that forwarded to these were removed in v4.0.0 ([#178](https://github.com/williamzujkowski/live-coding-music-mcp/issues/178)).
 - **4 MCP resources** for catalog browsing without burning tool calls: `strudel://examples`, `strudel://patterns`, `strudel://styles`, `strudel://docs/tools`.
 - **Real browser automation** of Strudel.cc through Playwright.
 - **Multi-session support** — every browser-touching tool accepts an optional `session_id`; sessions have isolated browser pages, undo/redo/history stacks, and audio-capture services.
@@ -257,7 +257,7 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 <!-- TOOLS:START -->
 
-**26 tools** across 14 categories:
+**27 tools** across 14 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -285,11 +285,12 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 </details>
 
-<details><summary><strong>Storage</strong> (1)</summary>
+<details><summary><strong>Storage</strong> (2)</summary>
 
 | Tool | Description |
 |------|-------------|
 | `pattern_store` | Persist patterns to disk and read them back.  |
+| `import_midi` | Convert a .mid file into a playable Strudel pattern (Phase 1: literal transcription, #201).  |
 
 </details>
 
@@ -383,7 +384,7 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 </details>
 
-_Auto-generated from source. 26 tools registered._
+_Auto-generated from source. 27 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -79,7 +79,7 @@ function categorizeTools(tools: Tool[]): Map<string, Tool[]> {
     init: 'Setup',
     edit_pattern: 'Pattern Editing', get_pattern: 'Pattern Editing',
     playback: 'Playback', set_tempo: 'Playback',
-    pattern_store: 'Storage',
+    pattern_store: 'Storage', import_midi: 'Storage',
     history: 'History',
     compose: 'Generation', generate_part: 'Generation', generate_rhythm: 'Generation',
     music_theory: 'Music Theory',

--- a/src/__tests__/unit/AiAssistConsolidation.test.ts
+++ b/src/__tests__/unit/AiAssistConsolidation.test.ts
@@ -16,7 +16,7 @@ function makeCtx() {
     geminiService: {
       isAvailable: jest.fn(() => false),
     } as any,
-    strudelEngine: {} as any, midiExportService: {} as any,
+    strudelEngine: {} as any, midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/AnalyzeConsolidation.test.ts
+++ b/src/__tests__/unit/AnalyzeConsolidation.test.ts
@@ -38,7 +38,7 @@ function makeCtx(initialized = true) {
       queryEvents: jest.fn(),
       transpile: jest.fn(),
     } as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/AudioCaptureConsolidation.test.ts
+++ b/src/__tests__/unit/AudioCaptureConsolidation.test.ts
@@ -25,7 +25,7 @@ function makeCtx() {
     controller: controller as any,
     perfMonitor: {} as any, store: {} as any, generator: {} as any, theory: {} as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => service as any,
     dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),

--- a/src/__tests__/unit/BrowserWindowConsolidation.test.ts
+++ b/src/__tests__/unit/BrowserWindowConsolidation.test.ts
@@ -14,7 +14,7 @@ function makeCtx() {
     controller: controller as any,
     perfMonitor: {} as any, store: {} as any, generator: {} as any, theory: {} as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/DiagnosticsConsolidation.test.ts
+++ b/src/__tests__/unit/DiagnosticsConsolidation.test.ts
@@ -31,7 +31,7 @@ function makeCtx(initialized = true) {
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/EditPatternConsolidation.test.ts
+++ b/src/__tests__/unit/EditPatternConsolidation.test.ts
@@ -24,7 +24,7 @@ function makeCtx(initialized = true) {
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/EffectConsolidation.test.ts
+++ b/src/__tests__/unit/EffectConsolidation.test.ts
@@ -10,7 +10,7 @@ function makeCtx() {
   const ctx: ToolContext = {
     controller: {} as any, perfMonitor: {} as any, store: {} as any, generator: {} as any,
     theory: {} as any, sessionManager: {} as any, geminiService: {} as any,
-    strudelEngine: {} as any, midiExportService: {} as any,
+    strudelEngine: {} as any, midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/GeneratePartConsolidation.test.ts
+++ b/src/__tests__/unit/GeneratePartConsolidation.test.ts
@@ -18,7 +18,7 @@ function makeCtx() {
     controller: {} as any, perfMonitor: {} as any, store: {} as any,
     generator: generator as any, theory: theory as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/GenerateRhythmConsolidation.test.ts
+++ b/src/__tests__/unit/GenerateRhythmConsolidation.test.ts
@@ -15,7 +15,7 @@ function makeCtx() {
     controller: {} as any, perfMonitor: {} as any, store: {} as any,
     generator: generator as any, theory: {} as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/HistoryConsolidation.test.ts
+++ b/src/__tests__/unit/HistoryConsolidation.test.ts
@@ -40,7 +40,7 @@ function makeCtx(initialized = true) {
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: (sid?: string) => {
       const b = getBundle(sid ?? 'default');

--- a/src/__tests__/unit/ImportMidiTool.test.ts
+++ b/src/__tests__/unit/ImportMidiTool.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for the import_midi tool wiring (#201).
+ *
+ * Exercises the storage-module dispatch path: source=base64 and source=path
+ * inputs, the security caps (size limit, path traversal), and the drum_map
+ * argument normalization (JSON string keys → number keys).
+ */
+
+import * as midiModule from '@tonejs/midi';
+const Midi: any = (midiModule as any).Midi || (midiModule as any).default?.Midi;
+
+import { execute } from '../../server/tools/storage';
+import type { ToolContext } from '../../server/tools/types';
+import { MIDIImportService } from '../../services/MIDIImportService';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { resolve } from 'path';
+
+function buildMidi(notes: Array<{ midi: number; time: number; channel?: number }>): Buffer {
+  const midi = new Midi();
+  midi.header.setTempo(120);
+  for (const n of notes) {
+    const t = midi.addTrack();
+    t.channel = n.channel ?? 0;
+    t.addNote({ midi: n.midi, time: n.time, duration: 0.1, velocity: 0.8 });
+  }
+  return Buffer.from(midi.toArray());
+}
+
+function makeCtx(): ToolContext {
+  return {
+    controller: {} as any,
+    perfMonitor: {} as any,
+    store: {} as any,
+    generator: {} as any,
+    theory: {} as any,
+    sessionManager: {} as any,
+    geminiService: {} as any,
+    strudelEngine: {} as any,
+    midiExportService: {} as any,
+    midiImportService: new MIDIImportService(),
+    getAudioCaptureService: async () => ({}) as any,
+    dropAudioCaptureService: jest.fn(),
+    getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }),
+    historyEntryId: () => 1,
+    dropHistory: jest.fn(),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+    isInitialized: () => true,
+    ensureInitialized: async () => {},
+    getController: () => ({}) as any,
+    getCurrentPatternSafe: async () => '',
+    writePatternSafe: async () => 'written',
+  };
+}
+
+describe('import_midi tool (#201)', () => {
+  describe('source=base64', () => {
+    it('converts a base64-encoded .mid into a Strudel pattern envelope', async () => {
+      const buf = buildMidi([{ midi: 60, time: 0 }, { midi: 64, time: 0.5 }]);
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: buf.toString('base64'),
+      }, makeCtx());
+      expect(result.ok).toBe(true);
+      expect(result.data.pattern).toContain('setcpm(120)');
+      expect(result.data.pattern).toContain('stack(');
+      expect(result.data.summary.notes).toBe(2);
+    });
+
+    it('rejects oversized base64 input', async () => {
+      // Allocate a 2.5MB string of "A" — base64 length exceeds MAX*2.
+      const huge = 'A'.repeat(2_500_000);
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: huge,
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+      expect(result.message).toMatch(/too large/i);
+    });
+
+    it('rejects empty data', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: '',
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+    });
+
+    it('rejects garbage base64 that does not parse as MIDI', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: Buffer.from('not a midi file').toString('base64'),
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+    });
+  });
+
+  describe('source=path', () => {
+    const fixtureDir = resolve('./patterns/midi');
+    const fixtureName = 'test-import-midi.mid';
+    const fixturePath = resolve(fixtureDir, fixtureName);
+
+    beforeAll(() => {
+      mkdirSync(fixtureDir, { recursive: true });
+      const buf = buildMidi([{ midi: 60, time: 0 }, { midi: 64, time: 0.5 }]);
+      writeFileSync(fixturePath, buf);
+    });
+
+    afterAll(() => {
+      try { rmSync(fixturePath); } catch { /* fixture cleanup is best-effort */ }
+    });
+
+    it('loads from patterns/midi/<basename>', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'path',
+        data: fixtureName,
+      }, makeCtx());
+      expect(result.ok).toBe(true);
+      expect(result.data.summary.notes).toBe(2);
+    });
+
+    it('blocks path traversal via "../"', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'path',
+        data: '../../etc/passwd',
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+      expect(result.message).toMatch(/traversal|invalid/i);
+    });
+
+    it('blocks absolute paths', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'path',
+        data: '/etc/passwd',
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+    });
+  });
+
+  describe('drum_map normalization', () => {
+    it('accepts JSON-style string keys for drum_map', async () => {
+      const buf = buildMidi([{ midi: 99, time: 0, channel: 9 }]);
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: buf.toString('base64'),
+        drum_map: { '99': 'cp' },
+      }, makeCtx());
+      expect(result.ok).toBe(true);
+      expect(result.data.summary.unmapped_drums).toEqual([]);
+      expect(result.data.pattern).toMatch(/s\("cp[^"]*"\)/);
+    });
+
+    it('rejects invalid drum_map entries', async () => {
+      const buf = buildMidi([{ midi: 99, time: 0, channel: 9 }]);
+      const result: any = await execute('import_midi', {
+        source: 'base64',
+        data: buf.toString('base64'),
+        drum_map: { 'not-a-number': 'cp' },
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+    });
+  });
+
+  describe('source validation', () => {
+    it('rejects unknown source values', async () => {
+      const result: any = await execute('import_midi', {
+        source: 'http',
+        data: 'http://example.com/file.mid',
+      }, makeCtx());
+      expect(result.ok).toBe(false);
+      expect(result.errorCategory).toBe('validation');
+    });
+  });
+});

--- a/src/__tests__/unit/MIDIImportService.test.ts
+++ b/src/__tests__/unit/MIDIImportService.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for MIDIImportService (Phase 1, #201).
+ *
+ * Fixtures are generated in-test via @tonejs/midi so the .mid bytes are
+ * deterministic, reviewable, and don't need a checked-in binary.
+ *
+ * The critical test is `should not drop drum events that share a grid step` —
+ * this guards against the collision bug the design spike exposed: emitting
+ * drums as a single merged s() string overwrites simultaneous samples.
+ */
+
+import * as midiModule from '@tonejs/midi';
+const Midi: any = (midiModule as any).Midi || (midiModule as any).default?.Midi;
+
+import { MIDIImportService, GM_DRUM_MAP, MAX_NOTES } from '../../services/MIDIImportService';
+
+/** Build a synthetic .mid Buffer with the given tracks. Returns raw bytes. */
+function buildMidi(
+  bpm: number,
+  tracks: Array<{
+    channel: number;
+    notes: Array<{ midi: number; time: number; duration?: number; velocity?: number }>;
+  }>,
+): Buffer {
+  const midi = new Midi();
+  midi.header.setTempo(bpm);
+  midi.header.timeSignatures.push({ ticks: 0, timeSignature: [4, 4] });
+  for (const t of tracks) {
+    const track = midi.addTrack();
+    track.channel = t.channel;
+    for (const n of t.notes) {
+      track.addNote({
+        midi: n.midi,
+        time: n.time,
+        duration: n.duration ?? 0.1,
+        velocity: n.velocity ?? 0.8,
+      });
+    }
+  }
+  return Buffer.from(midi.toArray());
+}
+
+describe('MIDIImportService', () => {
+  let service: MIDIImportService;
+  beforeEach(() => {
+    service = new MIDIImportService();
+  });
+
+  describe('basic conversion', () => {
+    it('emits setcpm + stack with the header tempo', () => {
+      const buf = buildMidi(140, [
+        { channel: 0, notes: [{ midi: 60, time: 0 }, { midi: 62, time: 0.5 }] },
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf);
+      expect(pattern).toContain('setcpm(140)');
+      expect(pattern).toContain('stack(');
+      expect(summary.bpm).toBe(140);
+      expect(summary.notes).toBe(2);
+    });
+
+    it('reports zero-lane fallback for an empty MIDI file', () => {
+      const buf = buildMidi(120, []);
+      const { pattern, summary } = service.convertBuffer(buf);
+      expect(pattern).toContain('silence');
+      expect(summary.lanes).toBe(0);
+      expect(summary.notes).toBe(0);
+    });
+  });
+
+  describe('drum lane splitting', () => {
+    it('should not drop drum events that share a grid step', () => {
+      // 1 bar at 120 BPM = 2 seconds. 16 steps/bar → 0.125s per step.
+      // Step 0: kick AND closed hat at the same instant.
+      // Step 4 (beat 2): snare AND closed hat at the same instant.
+      // The bug we're guarding against: merging into one s() string loses
+      // the hat hits, because step 0 can only hold one token.
+      const buf = buildMidi(120, [
+        {
+          channel: 9, // GM ch10
+          notes: [
+            { midi: 36, time: 0.0 },   // kick at step 0
+            { midi: 42, time: 0.0 },   // closed hat at step 0  ← same step as kick
+            { midi: 38, time: 0.5 },   // snare at step 4
+            { midi: 42, time: 0.5 },   // closed hat at step 4  ← same step as snare
+            { midi: 42, time: 0.25 },  // closed hat at step 2 (no collision)
+          ],
+        },
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf, { steps_per_cycle: 16 });
+
+      // Drum should produce one lane per distinct sample, alphabetically sorted: bd, hh, sd.
+      expect(summary.lanes).toBe(3);
+
+      // Kick lane: bd on step 0 only.
+      expect(pattern).toMatch(/s\("bd ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"\)/);
+      // Snare lane: sd on step 4 only.
+      expect(pattern).toMatch(/s\("~ ~ ~ ~ sd ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"\)/);
+      // Hat lane: hh on steps 0, 2, AND 4 — none dropped.
+      expect(pattern).toMatch(/s\("hh ~ hh ~ hh ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"\)/);
+    });
+
+    it('uses the default GM drum map for common samples', () => {
+      const buf = buildMidi(120, [
+        { channel: 9, notes: [
+          { midi: 36, time: 0 }, { midi: 38, time: 0.5 }, { midi: 42, time: 0.25 },
+          { midi: 46, time: 0.75 }, { midi: 49, time: 1.0 },
+        ]},
+      ]);
+      const { pattern } = service.convertBuffer(buf);
+      // bd, sd, hh, oh, cr all present
+      expect(pattern).toMatch(/s\("bd[^"]*"\)/);
+      expect(pattern).toMatch(/s\("[^"]*sd[^"]*"\)/);
+      expect(pattern).toMatch(/s\("[^"]*hh[^"]*"\)/);
+      expect(pattern).toMatch(/s\("[^"]*oh[^"]*"\)/);
+      expect(pattern).toMatch(/s\("[^"]*cr[^"]*"\)/);
+    });
+
+    it('surfaces unmapped drum notes in the summary rather than emitting garbage', () => {
+      // MIDI note 99 isn't in the GM percussion map.
+      const buf = buildMidi(120, [
+        { channel: 9, notes: [
+          { midi: 36, time: 0 },   // mapped → bd
+          { midi: 99, time: 0.5 }, // unmapped
+        ]},
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf);
+      expect(summary.unmapped_drums).toContain(99);
+      // Unmapped notes don't appear in the pattern body.
+      expect(pattern).not.toContain('n99');
+      expect(pattern).not.toMatch(/s\("99/);
+    });
+
+    it('accepts user drum_map overrides', () => {
+      const buf = buildMidi(120, [
+        { channel: 9, notes: [{ midi: 99, time: 0 }] },
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf, { drum_map: { 99: 'cp' } });
+      expect(summary.unmapped_drums).toEqual([]);
+      expect(pattern).toMatch(/s\("cp[^"]*"\)/);
+    });
+  });
+
+  describe('pitched polyphony', () => {
+    it('merges simultaneous pitched notes into [a,b,c] chord tokens', () => {
+      // C major triad at step 0, single E at step 4.
+      const buf = buildMidi(120, [
+        { channel: 0, notes: [
+          { midi: 60, time: 0 },   // C4
+          { midi: 64, time: 0 },   // E4
+          { midi: 67, time: 0 },   // G4
+          { midi: 64, time: 0.5 }, // E4 alone
+        ]},
+      ]);
+      const { pattern } = service.convertBuffer(buf, { steps_per_cycle: 16 });
+      expect(pattern).toContain('[c4,e4,g4]');
+      // Single E4 should appear as plain "e4" (no brackets)
+      expect(pattern).toMatch(/\[c4,e4,g4\] ~ ~ ~ e4 /);
+    });
+
+    it('renders single-bar melodies without <...> alternation wrapper', () => {
+      const buf = buildMidi(120, [
+        { channel: 0, notes: [
+          { midi: 60, time: 0 }, { midi: 62, time: 0.5 },
+          { midi: 64, time: 1.0 }, { midi: 65, time: 1.5 },
+        ]},
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf, { steps_per_cycle: 16 });
+      expect(summary.bars).toBe(1);
+      expect(pattern).not.toContain('<');
+      expect(pattern).toContain('c4 ~ ~ ~ d4 ~ ~ ~ e4 ~ ~ ~ f4');
+    });
+
+    it('renders multi-bar melodies with <bar1 bar2> alternation', () => {
+      const buf = buildMidi(120, [
+        { channel: 0, notes: [
+          { midi: 60, time: 0 },        // bar 1
+          { midi: 62, time: 2.0 },      // bar 2
+        ]},
+      ]);
+      const { pattern, summary } = service.convertBuffer(buf, { steps_per_cycle: 16 });
+      expect(summary.bars).toBe(2);
+      expect(pattern).toContain('note("<[c4 ');
+      expect(pattern).toContain('] [d4 ');
+      expect(pattern).toContain(']>").s("piano")');
+    });
+  });
+
+  describe('options & validation', () => {
+    it('honors bars cap', () => {
+      const buf = buildMidi(120, [
+        { channel: 0, notes: [
+          { midi: 60, time: 0 }, { midi: 62, time: 2.0 }, { midi: 64, time: 4.0 },
+        ]},
+      ]);
+      const { summary } = service.convertBuffer(buf, { bars: 2 });
+      expect(summary.bars).toBe(2);
+    });
+
+    it('honors steps_per_cycle', () => {
+      const buf = buildMidi(120, [
+        { channel: 0, notes: [{ midi: 60, time: 0 }, { midi: 62, time: 1.0 }] },
+      ]);
+      const { summary } = service.convertBuffer(buf, { steps_per_cycle: 8 });
+      expect(summary.steps_per_cycle).toBe(8);
+    });
+
+    it('rejects out-of-range steps_per_cycle', () => {
+      const buf = buildMidi(120, [{ channel: 0, notes: [{ midi: 60, time: 0 }] }]);
+      expect(() => service.convertBuffer(buf, { steps_per_cycle: 0 })).toThrow(/Invalid steps_per_cycle/);
+      expect(() => service.convertBuffer(buf, { steps_per_cycle: 65 })).toThrow(/Invalid steps_per_cycle/);
+      expect(() => service.convertBuffer(buf, { steps_per_cycle: 1.5 })).toThrow(/Invalid steps_per_cycle/);
+    });
+
+    it('throws on unparseable input', () => {
+      const garbage = Buffer.from('not a midi file');
+      expect(() => service.convertBuffer(garbage)).toThrow(/parse/i);
+    });
+
+    it('refuses pathologically large note counts', () => {
+      // Build a track with MAX_NOTES + 1 notes; should bail before rendering.
+      const notes = Array.from({ length: MAX_NOTES + 1 }, (_, i) => ({
+        midi: 60,
+        time: i * 0.001,
+        duration: 0.001,
+      }));
+      const buf = buildMidi(120, [{ channel: 0, notes }]);
+      expect(() => service.convertBuffer(buf)).toThrow(/too many notes/);
+    });
+  });
+
+  describe('GM_DRUM_MAP', () => {
+    it('covers the common GM percussion notes (35-59)', () => {
+      const required = [35, 36, 38, 40, 42, 46, 49, 51];
+      for (const n of required) {
+        expect(GM_DRUM_MAP[n]).toBeDefined();
+        expect(typeof GM_DRUM_MAP[n]).toBe('string');
+        expect(GM_DRUM_MAP[n].length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/__tests__/unit/MultiSession.test.ts
+++ b/src/__tests__/unit/MultiSession.test.ts
@@ -51,7 +51,7 @@ function makeCtx(sessions: Record<string, StrudelController>, legacyController: 
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/MusicTheoryConsolidation.test.ts
+++ b/src/__tests__/unit/MusicTheoryConsolidation.test.ts
@@ -18,7 +18,7 @@ function makeCtx() {
     controller: {} as any, perfMonitor: {} as any, store: {} as any,
     generator: generator as any, theory: theory as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/PatternStoreConsolidation.test.ts
+++ b/src/__tests__/unit/PatternStoreConsolidation.test.ts
@@ -32,7 +32,7 @@ function makeCtx(): { ctx: ToolContext; store: any; pattern: { current: string }
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/PlaybackConsolidation.test.ts
+++ b/src/__tests__/unit/PlaybackConsolidation.test.ts
@@ -11,7 +11,7 @@ function makeCtx(initialized = true) {
     controller: controller as any,
     perfMonitor: {} as any, store: {} as any, generator: {} as any, theory: {} as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/Resources.test.ts
+++ b/src/__tests__/unit/Resources.test.ts
@@ -133,8 +133,9 @@ describe('MCP resources', () => {
     it('returns every registered tool with a description', async () => {
       const result = await readResource('strudel://docs/tools', ctx);
       const data = JSON.parse(result.text);
-      // 25 consolidated tool defs + the unlisted `init` we prepend = 26
-      expect(data.count).toBe(26);
+      // 26 consolidated tool defs + the unlisted `init` we prepend = 27
+      // (import_midi added in #201)
+      expect(data.count).toBe(27);
       const initTool = data.tools.find((t: any) => t.name === 'init');
       expect(initTool).toBeDefined();
       const compose = data.tools.find((t: any) => t.name === 'compose');

--- a/src/__tests__/unit/SessionConsolidation.test.ts
+++ b/src/__tests__/unit/SessionConsolidation.test.ts
@@ -29,7 +29,7 @@ function makeCtx() {
     generator: {} as any, theory: {} as any,
     sessionManager: sm as any,
     geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }),
     historyEntryId: () => 1,

--- a/src/__tests__/unit/ShapeConsolidation.test.ts
+++ b/src/__tests__/unit/ShapeConsolidation.test.ts
@@ -12,7 +12,7 @@ function makeCtx() {
     controller: controller as any,
     perfMonitor: {} as any, store: {} as any, generator: {} as any, theory: {} as any,
     sessionManager: {} as any, geminiService: {} as any, strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/__tests__/unit/TransformConsolidation.test.ts
+++ b/src/__tests__/unit/TransformConsolidation.test.ts
@@ -22,7 +22,7 @@ function makeCtx() {
     sessionManager: {} as any,
     geminiService: {} as any,
     strudelEngine: {} as any,
-    midiExportService: {} as any,
+    midiExportService: {} as any, midiImportService: {} as any,
     getAudioCaptureService: async (_sid?: string) => ({}) as any, dropAudioCaptureService: jest.fn(),
     getHistory: () => ({ undoStack: [], redoStack: [], historyStack: [], maxHistory: 100 }), historyEntryId: () => 1, dropHistory: jest.fn(),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,6 +14,7 @@ import { PatternGenerator } from '../services/PatternGenerator.js';
 import { GeminiService } from '../services/GeminiService.js';
 import { AudioCaptureService } from '../services/AudioCaptureService.js';
 import { MIDIExportService } from '../services/MIDIExportService.js';
+import { MIDIImportService } from '../services/MIDIImportService.js';
 import { SessionManager } from '../services/SessionManager.js';
 import { readFileSync, existsSync } from 'fs';
 import { Logger } from '../utils/Logger.js';
@@ -68,6 +69,7 @@ export class StrudelMCPServer {
    */
   private audioCaptureServices: Map<string, AudioCaptureService> = new Map();
   private midiExportService: MIDIExportService;
+  private midiImportService: MIDIImportService;
   private sessionManager: SessionManager;
   private logger: Logger;
   private perfMonitor: PerformanceMonitor;
@@ -110,6 +112,7 @@ export class StrudelMCPServer {
     this.generator = new PatternGenerator();
     this.geminiService = new GeminiService();
     this.midiExportService = new MIDIExportService();
+    this.midiImportService = new MIDIImportService();
     this.sessionManager = new SessionManager(config.headless, audioAnalysisConfig);
     this.logger = new Logger();
     this.perfMonitor = new PerformanceMonitor();
@@ -365,6 +368,7 @@ export class StrudelMCPServer {
       geminiService: this.geminiService,
       strudelEngine: this.strudelEngine,
       midiExportService: this.midiExportService,
+      midiImportService: this.midiImportService,
       getAudioCaptureService: (sessionId?: string) => this.getAudioCaptureService(sessionId),
       dropAudioCaptureService: (sessionId: string) => { this.audioCaptureServices.delete(sessionId); },
       getHistory: (sessionId?: string) => {

--- a/src/server/tools/storage.ts
+++ b/src/server/tools/storage.ts
@@ -7,6 +7,12 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext, ToolModule } from './types.js';
 import { InputValidator } from '../../utils/InputValidator.js';
+import { ok, err } from './types.js';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+/** Hard cap on .mid input size — protects @tonejs/midi from pathological allocations. */
+const MAX_MIDI_BYTES = 1_000_000; // 1 MB
 
 const SESSION_ID_PROP = {
   session_id: {
@@ -39,6 +45,51 @@ export const tools: Tool[] = [
         ...SESSION_ID_PROP,
       },
       required: ['action'],
+    },
+  },
+  {
+    name: 'import_midi',
+    description:
+      'Convert a .mid file into a playable Strudel pattern (Phase 1: literal transcription, #201). ' +
+      'Use source="base64" with data=<base64 string> for inline bytes, or source="path" with data=<basename> ' +
+      'to read from the patterns/midi/ directory (path traversal blocked). ' +
+      'Drum tracks (MIDI channel 10) emit one s() lane per sample so simultaneous kicks/hats do not collide. ' +
+      'Pitched tracks emit note("...").s("piano") with simultaneous notes merged into [a,b,c] chord tokens. ' +
+      'Phase 2+ (structural compression, voice separation, LLM idiomatic pass) tracked in separate issues. ' +
+      'Example: import_midi({ source: "path", data: "drumloop.mid", steps_per_cycle: 16 }). ' +
+      'For the reverse direction (Strudel → MIDI) use the analyze tool with task="export_midi".',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source: {
+          type: 'string',
+          enum: ['base64', 'path'],
+          description: 'How to interpret `data` — raw base64 bytes or a filename under patterns/midi/',
+        },
+        data: {
+          type: 'string',
+          description:
+            'For source=base64: base64-encoded .mid bytes (≤1MB decoded). ' +
+            'For source=path: basename of a .mid file under ./patterns/midi/ (path-traversal blocked).',
+        },
+        steps_per_cycle: {
+          type: 'number',
+          description: 'Grid resolution per bar (integer 1-64). Default 16.',
+        },
+        bars: {
+          type: 'number',
+          description: 'Cap on bars to emit. Default: full file.',
+        },
+        drum_map: {
+          type: 'object',
+          description:
+            'Optional override / extension to the default GM percussion map. ' +
+            'Keys are MIDI note numbers (as strings, since JSON object keys), values are Strudel sample names. ' +
+            'Example: { "60": "cp", "61": "rim" }. Unmapped drums fall back to rests and are surfaced in the result summary.',
+          additionalProperties: { type: 'string' },
+        },
+      },
+      required: ['source', 'data'],
     },
   },
 ];
@@ -75,6 +126,88 @@ async function doList(args: any, ctx: ToolContext): Promise<unknown> {
   ).join('\n') || 'No patterns found';
 }
 
+/**
+ * Resolve `args.data` to a Buffer based on `args.source`. Enforces the
+ * 1 MB cap and, for path sources, blocks path traversal by clamping to
+ * `./patterns/midi/` via `path.basename` (mirrors PatternStore).
+ */
+async function loadMidiBuffer(args: any): Promise<Buffer> {
+  const source = args?.source;
+  const data = args?.data;
+  if (typeof data !== 'string' || data.length === 0) {
+    throw new Error('Invalid data: must be a non-empty string');
+  }
+  if (source === 'base64') {
+    // Decoded length ≤ raw length × 3/4; reject before allocating.
+    if (data.length > MAX_MIDI_BYTES * 2) {
+      throw new Error(`MIDI base64 input too large (>${MAX_MIDI_BYTES} bytes decoded).`);
+    }
+    const buf = Buffer.from(data, 'base64');
+    if (buf.length === 0) {
+      throw new Error('Invalid data: base64 decoded to zero bytes');
+    }
+    if (buf.length > MAX_MIDI_BYTES) {
+      throw new Error(`MIDI input too large (${buf.length} > ${MAX_MIDI_BYTES} bytes).`);
+    }
+    return buf;
+  }
+  if (source === 'path') {
+    InputValidator.validateStringLength(data, 'data', 255, false);
+    const safeName = path.basename(data);
+    if (safeName !== data) {
+      throw new Error('Invalid filename: path traversal detected');
+    }
+    const fullPath = path.resolve('./patterns/midi', safeName);
+    const expectedRoot = path.resolve('./patterns/midi');
+    if (!fullPath.startsWith(expectedRoot + path.sep)) {
+      throw new Error('Invalid filename: must resolve under patterns/midi/');
+    }
+    const buf = await readFile(fullPath);
+    if (buf.length > MAX_MIDI_BYTES) {
+      throw new Error(`MIDI input too large (${buf.length} > ${MAX_MIDI_BYTES} bytes).`);
+    }
+    return buf;
+  }
+  throw new Error(`Invalid source: ${source}. Must be "base64" or "path".`);
+}
+
+async function doImportMidi(args: any, ctx: ToolContext): Promise<unknown> {
+  let buffer: Buffer;
+  try {
+    buffer = await loadMidiBuffer(args);
+  } catch (e: any) {
+    return err('validation', e?.message ?? 'Failed to load MIDI input');
+  }
+
+  // Normalize drum_map keys: JSON object keys are strings, the service wants number keys.
+  let drumMapNormalized: Record<number, string> | undefined;
+  if (args?.drum_map && typeof args.drum_map === 'object') {
+    drumMapNormalized = {};
+    for (const [k, v] of Object.entries(args.drum_map)) {
+      const n = Number(k);
+      if (!Number.isInteger(n) || n < 0 || n > 127 || typeof v !== 'string' || v.length === 0) {
+        return err('validation', `Invalid drum_map entry: ${k} -> ${String(v)}`);
+      }
+      drumMapNormalized[n] = v;
+    }
+  }
+
+  try {
+    const result = ctx.midiImportService.convertBuffer(buffer, {
+      steps_per_cycle: args?.steps_per_cycle,
+      bars: args?.bars,
+      drum_map: drumMapNormalized,
+    });
+    return ok(result);
+  } catch (e: any) {
+    const msg = e?.message ?? String(e);
+    if (/parse|invalid|must be/i.test(msg)) {
+      return err('validation', msg);
+    }
+    return err('internal', msg);
+  }
+}
+
 export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
   const sid: string | undefined = args?.session_id;
   switch (name) {
@@ -91,6 +224,9 @@ export async function execute(name: string, args: any, ctx: ToolContext): Promis
       // Unreachable due to enum check above, but TypeScript wants it.
       return undefined;
     }
+
+    case 'import_midi':
+      return await doImportMidi(args, ctx);
 
     default:
       throw new Error(`storage module does not handle tool: ${name}`);

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -14,6 +14,7 @@ import type { PatternGenerator } from '../../services/PatternGenerator.js';
 import type { MusicTheory } from '../../services/MusicTheory.js';
 import type { SessionManager } from '../../services/SessionManager.js';
 import type { MIDIExportService } from '../../services/MIDIExportService.js';
+import type { MIDIImportService } from '../../services/MIDIImportService.js';
 import type { AudioCaptureService } from '../../services/AudioCaptureService.js';
 import type { GeminiService } from '../../services/GeminiService.js';
 import type { StrudelEngine } from '../../services/StrudelEngine.js';
@@ -58,6 +59,7 @@ export interface ToolContext {
   geminiService: GeminiService;
   strudelEngine: StrudelEngine;
   midiExportService: MIDIExportService;
+  midiImportService: MIDIImportService;
   /**
    * Lazily returns the per-session AudioCaptureService (#180). When no
    * `sessionId` is given, returns the default-session service (legacy

--- a/src/services/MIDIImportService.ts
+++ b/src/services/MIDIImportService.ts
@@ -1,0 +1,264 @@
+/**
+ * MIDI Import Service (Phase 1 — literal transcription).
+ *
+ * Mirror of MIDIExportService: parses a `.mid` byte buffer and emits a
+ * playable Strudel pattern. Phase 1 is deliberately literal — no motif
+ * detection, no bar deduplication, no LLM idiomatic post-pass. Output
+ * is verbose-but-correct. Tracked by #201.
+ *
+ * Drum tracks (MIDI channel index 9, i.e. GM ch10) emit **one s() lane
+ * per distinct sample name**, not one merged string. This avoids the
+ * collision drop the prototyping spike exposed: events sharing a grid
+ * step in a single string can only hold one token, so hat hits that
+ * land on the same step as a kick get silently overwritten.
+ *
+ * Round-trip is not lossless: timing is quantized, velocity is dropped,
+ * voice information for two-voice melodies on one channel collapses
+ * into chord tokens. Phase 2-4 issues track each of those.
+ *
+ * @example
+ * const svc = new MIDIImportService();
+ * const result = svc.convertBuffer(buffer);
+ * console.log(result.pattern);
+ * // setcpm(120)
+ * // stack(
+ * //   s("bd ~ ~ ~ ~ ~ ~ ~ bd ~ ~ ~ ~ ~ ~ ~"),
+ * //   ...
+ * // )
+ */
+
+import * as midiModule from '@tonejs/midi';
+const Midi = (midiModule as any).Midi || (midiModule as any).default?.Midi;
+
+/** Options accepted by `convertBuffer`. */
+export interface MIDIImportOptions {
+  /** Grid resolution per bar (steps). Default 16. */
+  steps_per_cycle?: number;
+  /** Cap on bars to emit. Default: full file. */
+  bars?: number;
+  /** Overrides / extends the default GM drum map (MIDI note → sample). */
+  drum_map?: Record<number, string>;
+}
+
+/** Per-call summary returned alongside the pattern. */
+export interface MIDIImportSummary {
+  /** BPM read from the file header (rounded). */
+  bpm: number;
+  /** Number of bars emitted. */
+  bars: number;
+  /** Lane count after drum splitting and pitched grouping. */
+  lanes: number;
+  /** Total parsed note events (across all tracks, pre-quantize). */
+  notes: number;
+  /** Drum MIDI note numbers seen in input that had no mapping — emitted as rests. */
+  unmapped_drums: number[];
+  /** Grid resolution actually used. */
+  steps_per_cycle: number;
+}
+
+/** Successful conversion result. */
+export interface MIDIImportResult {
+  pattern: string;
+  summary: MIDIImportSummary;
+}
+
+/**
+ * GM percussion map → Strudel sample names. Comprehensive enough for
+ * most real-world drum tracks; the user can override or extend via
+ * `drum_map`.
+ *
+ * Toms collapse onto {lt, mt, ht} since Strudel's default sample bank
+ * exposes those three rather than the GM five. Anything not listed
+ * falls back to `~` and is surfaced in `summary.unmapped_drums`.
+ */
+export const GM_DRUM_MAP: Record<number, string> = {
+  35: 'bd', 36: 'bd',                     // bass drum
+  37: 'rim',                              // side stick
+  38: 'sd', 40: 'sd',                     // snare
+  39: 'cp',                               // hand clap
+  41: 'lt', 43: 'lt',                     // low/floor toms
+  42: 'hh', 44: 'hh',                     // closed / pedal hat
+  45: 'mt', 47: 'mt',                     // mid toms
+  46: 'oh',                               // open hat
+  48: 'ht', 50: 'ht',                     // high toms
+  49: 'cr', 52: 'cr', 55: 'cr', 57: 'cr', // crashes
+  51: 'rd', 53: 'rd', 59: 'rd',           // rides
+  54: 'tb',                               // tambourine
+  56: 'cb',                               // cowbell
+};
+
+/** Maximum tracks emitted before we bail out (protects against pathological input). */
+export const MAX_TRACKS = 64;
+/** Maximum total note count after parse — protects memory in the renderer. */
+export const MAX_NOTES = 50_000;
+
+/** Convert MIDI note number to Strudel pitch notation (e.g. 60 → "c4"). */
+function midiToNoteName(midi: number): string {
+  const names = ['c', 'c#', 'd', 'd#', 'e', 'f', 'f#', 'g', 'g#', 'a', 'a#', 'b'];
+  const octave = Math.floor(midi / 12) - 1;
+  return `${names[midi % 12]}${octave}`;
+}
+
+/**
+ * Build the per-step token array for a single drum sample within a track.
+ * Returns a length-`totalSteps` string array, each slot either the sample
+ * name or `~` (rest). The caller renders one s() lane per result.
+ */
+function buildDrumLane(
+  notes: { time: number }[],
+  sample: string,
+  stepSeconds: number,
+  totalSteps: number,
+): string[] {
+  const slots = new Array<string>(totalSteps).fill('~');
+  for (const n of notes) {
+    const step = Math.round(n.time / stepSeconds);
+    if (step < 0 || step >= totalSteps) continue;
+    slots[step] = sample;
+  }
+  return slots;
+}
+
+/**
+ * Build the per-step token array for a pitched track. Simultaneous notes
+ * at the same step merge into `[a,b,c]` chord tokens (Strudel's parallel
+ * notation within a single step).
+ */
+function buildPitchLane(
+  notes: { time: number; midi: number }[],
+  stepSeconds: number,
+  totalSteps: number,
+): string[] {
+  const slots = new Array<string[] | null>(totalSteps).fill(null);
+  for (const n of notes) {
+    const step = Math.round(n.time / stepSeconds);
+    if (step < 0 || step >= totalSteps) continue;
+    const name = midiToNoteName(n.midi);
+    if (slots[step] === null) {
+      slots[step] = [name];
+    } else {
+      slots[step]!.push(name);
+    }
+  }
+  return slots.map((s) => {
+    if (s === null) return '~';
+    if (s.length === 1) return s[0];
+    return `[${s.join(',')}]`;
+  });
+}
+
+/** Render a per-step token array as a Strudel mini-notation string, split into bars. */
+function renderBars(slots: string[], stepsPerCycle: number, bars: number): string {
+  const barStrings: string[] = [];
+  for (let b = 0; b < bars; b++) {
+    const slice = slots.slice(b * stepsPerCycle, (b + 1) * stepsPerCycle);
+    barStrings.push(slice.join(' '));
+  }
+  if (barStrings.length === 1) {
+    return barStrings[0];
+  }
+  // Wrap each bar in [...] so each cycle plays the whole bar; alternate per outer cycle.
+  return `<${barStrings.map((s) => `[${s}]`).join(' ')}>`;
+}
+
+export class MIDIImportService {
+  /**
+   * Convert a `.mid` byte buffer to a Strudel pattern string.
+   *
+   * @throws Error on parse failure or input that exceeds the configured caps.
+   */
+  convertBuffer(buffer: Buffer | Uint8Array, options: MIDIImportOptions = {}): MIDIImportResult {
+    const stepsPerCycle = options.steps_per_cycle ?? 16;
+    if (!Number.isInteger(stepsPerCycle) || stepsPerCycle < 1 || stepsPerCycle > 64) {
+      throw new Error(`Invalid steps_per_cycle: ${stepsPerCycle}. Must be an integer in [1, 64].`);
+    }
+
+    let midi: any;
+    try {
+      midi = new Midi(buffer);
+    } catch (e: any) {
+      throw new Error(`Failed to parse MIDI buffer: ${e?.message ?? e}`);
+    }
+
+    if (midi.tracks.length > MAX_TRACKS) {
+      throw new Error(`MIDI file has too many tracks (${midi.tracks.length} > ${MAX_TRACKS}).`);
+    }
+
+    // Count total notes pre-render so we can fail fast on pathological inputs.
+    let totalNotes = 0;
+    let lastEnd = 0;
+    for (const t of midi.tracks) {
+      for (const n of t.notes) {
+        totalNotes++;
+        if (totalNotes > MAX_NOTES) {
+          throw new Error(`MIDI file has too many notes (>${MAX_NOTES}).`);
+        }
+        if (n.time + n.duration > lastEnd) lastEnd = n.time + n.duration;
+      }
+    }
+
+    const bpm = Math.round(midi.header.tempos[0]?.bpm ?? 120);
+    const secondsPerBeat = 60 / bpm;
+    const secondsPerBar = secondsPerBeat * 4;
+    const stepSeconds = secondsPerBar / stepsPerCycle;
+
+    const fileBars = Math.max(1, Math.ceil(lastEnd / secondsPerBar) || 1);
+    const bars = options.bars && options.bars > 0 ? Math.min(options.bars, fileBars) : fileBars;
+    const totalSteps = bars * stepsPerCycle;
+
+    const drumMap: Record<number, string> = { ...GM_DRUM_MAP, ...(options.drum_map ?? {}) };
+    const unmappedSet = new Set<number>();
+
+    const lanes: string[] = [];
+
+    for (const track of midi.tracks) {
+      if (track.notes.length === 0) continue;
+      const isDrum = track.channel === 9;
+
+      if (isDrum) {
+        // Group by mapped sample; emit one s() lane per sample.
+        const bySample = new Map<string, { midi: number; time: number }[]>();
+        for (const n of track.notes) {
+          const sample = drumMap[n.midi];
+          if (!sample) {
+            unmappedSet.add(n.midi);
+            continue;
+          }
+          if (!bySample.has(sample)) bySample.set(sample, []);
+          bySample.get(sample)!.push({ midi: n.midi, time: n.time });
+        }
+        // Sort sample names deterministically so output is stable.
+        const samples = Array.from(bySample.keys()).sort();
+        for (const sample of samples) {
+          const slots = buildDrumLane(bySample.get(sample)!, sample, stepSeconds, totalSteps);
+          const body = renderBars(slots, stepsPerCycle, bars);
+          lanes.push(`  s("${body}")`);
+        }
+      } else {
+        const slots = buildPitchLane(
+          track.notes.map((n: any) => ({ time: n.time, midi: n.midi })),
+          stepSeconds,
+          totalSteps,
+        );
+        const body = renderBars(slots, stepsPerCycle, bars);
+        lanes.push(`  note("${body}").s("piano")`);
+      }
+    }
+
+    const out = lanes.length === 0
+      ? `setcpm(${bpm})\n\n// (no playable notes after parse)\nsilence`
+      : `setcpm(${bpm})\n\nstack(\n${lanes.join(',\n')}\n)`;
+
+    return {
+      pattern: out,
+      summary: {
+        bpm,
+        bars,
+        lanes: lanes.length,
+        notes: totalNotes,
+        unmapped_drums: Array.from(unmappedSet).sort((a, b) => a - b),
+        steps_per_cycle: stepsPerCycle,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- New `import_midi` MCP tool — converts a .mid file into a playable Strudel pattern.
- Mirror of `MIDIExportService`; reuses `@tonejs/midi` (already a dep), no browser dep.
- Phase 1 only (deliberately literal). Phases 2–4 are separate issues.

Closes #201.

## What's in

`src/services/MIDIImportService.ts` parses .mid bytes, snaps event onsets to a configurable grid (default 16 steps/bar), and emits `setcpm + stack(...)` with:
- **One `s(...)` lane per drum sample** — the spike that preceded this revealed that merging drums into one string silently drops events that share a grid step (kick + hi-hat at beat 1). Per-sample lanes fix this; a regression test (`should not drop drum events that share a grid step`) guards it.
- **`note(...)` per pitched track** with simultaneous notes merged into `[a,b,c]` chord tokens.
- **Default GM percussion map** covering 35–59; user-overridable via the `drum_map` arg.
- **Multi-bar** content wraps in `<bar1 bar2 ...>` alternation (Phase 2 will collapse identical bars).

Wired via `src/server/tools/storage.ts` with envelope responses (`ok` / `err`). Two inputs:
- `source: "base64"` — inline bytes
- `source: "path"` — basename under `./patterns/midi/`, path traversal blocked via `path.basename` + allow-list

## Security

`.mid` parsing is an untrusted-input boundary not covered by the original consensus vote. This adds:
- 1 MB input cap (base64 pre-decode and post-decode, plus file-read)
- 50k note cap (protects renderer against pathological inputs)
- `path.basename` + `patterns/midi/` allow-list for `source: path`

## Out of scope

- **Phase 2** — structural compression (`*N`, `<...>`, `[...]` collapsing).
- **Phase 3** — voice separation + motif induction. Needs explicit complexity budget; see #201.
- **Phase 4** — LLM idiomatic post-pass with round-trip MIDI-diff validation. Opt-in, requires API key.

Each is a separate follow-up issue when/if it's worth building.

## Test plan

- [x] `npm run build` — clean (regenerates README tool table)
- [x] `npm test` — 1773 pass, 51 skipped (browser), 0 fail
- [x] Drum collision regression test passes
- [x] Polyphony merge produces `[c4,e4,g4]` chord tokens
- [x] Security caps: oversized base64 rejected, garbage rejected, path traversal blocked
- [x] `drum_map` JSON string-key normalization works
- [x] README auto-regenerated; not hand-edited

## Notes

The brainstorm chain — research → architecture proposal → 4-of-7 consensus vote (3 errored on Gemini circuit-breaker) → spike against a synthetic fixture → falsification (discovered the drum collision) → implementation — is captured in #201. The drum collision was the bug the consensus vote missed; the spike caught it before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)