### PR TITLE
chore(ci): tighten workflow permissions + pin Dockerfile base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+  # Docker base image is pinned by SHA — Dependabot bumps the digest when
+  # node:22-alpine moves so the pin doesn't go stale.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for GITHUB_TOKEN — the build job only needs to
+# read the repo. Individual jobs can elevate if they ever need to.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,12 @@ on:
         default: true
         type: boolean
 
-# Required for OIDC trusted publishing and build provenance attestation
+# Least-privilege default at the workflow level — read-only.
+# The publish job opts into the writes it needs (release upload, version
+# bump push, attestation log). Scoping at the job level rather than
+# top-level was Scorecard finding #18.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 # A real release goes through the `release: published` event. A
 # workflow_dispatch run is dry by default — it exercises the whole
@@ -39,6 +40,13 @@ jobs:
     # Environment is optional but recommended for additional protection
     # Configure this environment in GitHub repo settings if desired
     environment: npm-publish
+    # contents:write — version bump push + release artifact upload
+    # id-token:write — OIDC trusted publishing to npm
+    # attestations:write — SLSA build provenance log
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN npm prune --production && \
     rm -rf ~/.npm /tmp/*
 
 # Stage 2: Runtime (smaller image)
-FROM node:22-alpine AS runtime
+FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS runtime
 
 # Install Chromium and cleanup in single layer
 RUN apk add --no-cache chromium && \


### PR DESCRIPTION
## Summary

Clears three error-severity Scorecard findings. No runtime behavior change.

| Finding | Fix |
|---|---|
| **#2** — `ci.yml` had no top-level permissions | Added `permissions: contents: read` at workflow level. |
| **#18** — `publish.yml` had `contents: write` + `id-token: write` + `attestations: write` at workflow level | Moved into the publish job. Workflow-level now `contents: read`. |
| **#8, #9** — `Dockerfile` base image unpinned in both stages | Pinned `node:22-alpine` to `sha256:968df3...0966920` (current multi-arch index digest, verified via `docker buildx imagetools inspect`). |

Also: added a `docker` ecosystem entry to `.github/dependabot.yml` so the SHA pin doesn't silently go stale — Dependabot bumps it weekly when `node:22-alpine` moves.

## Why each

- **Least privilege.** `contents: write` at the workflow level grants every step write access to the repo; only the publish job actually needs it (version bump push, release upload). Scoping at the job level is the standard fix.
- **Supply-chain pinning.** A floating `node:22-alpine` tag means any reproduction of the build from a different point in time pulls a different base image. SHA-pinning makes the build deterministic; Dependabot keeps the pin current.

## Test plan

- [x] No code paths affected — CI just exercises the workflows themselves.
- [x] CI's `build (22.x)` job runs successfully on the PR.
- [x] Publish workflow is `release: published` triggered or `workflow_dispatch` only; not run by this PR.
- [x] Dockerfile builds locally with the pinned digest (the digest matches the current `node:22-alpine` tag, so this is a no-op for fresh pulls).

## Out of scope

Other Scorecard findings worth addressing separately:
- **#13** (SAST not run) — enable CodeQL workflow (separate PR)
- **#14** (no fuzzing) — overkill for this codebase
- **#12** (OpenSSF Best Practices badge) — paperwork
- **#11** (code review on changesets) — solo project, n/a
- **#1** (branch protection) — conscious choice for solo project

🤖 Generated with [Claude Code](https://claude.com/claude-code)