### PR TITLE
chore(ci): enable CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+# Static analysis (SAST) for the TypeScript source. Closes Scorecard finding #13
+# — previously no SAST tool was running on commits. CodeQL runs on every
+# push/PR to main plus a weekly cron, and writes findings to the Security tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Wednesday 09:00 UTC — staggered from Dependabot's weekly run.
+    - cron: '0 9 * * 3'
+
+# Default workflow permissions are read-only. The analyze job opts into
+# security-events:write so it can upload SARIF results.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required to upload SARIF results to the Security tab
+      security-events: write
+      # Required for private repos to fetch packages (no-op here)
+      packages: read
+      # CodeQL action reads run metadata to deduplicate runs
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          languages: ${{ matrix.language }}
+          # Use the extended query suite — same set Scorecard expects to see
+          # for the SASTID rule to register coverage.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Clears Scorecard finding #13 (no SAST tool runs on commits) by adding a GitHub-native CodeQL workflow. Findings land in the repo's Security tab; no third-party service or extra cost.

## What

- `.github/workflows/codeql.yml` — runs on every push/PR to `main` plus a weekly Wednesday cron (staggered from Dependabot's weekly run).
- Language: `javascript-typescript` (unified for TS sources).
- Query suite: `security-extended` — what Scorecard's SASTID rule checks for.
- Pinned to the same codeql-action SHA that `scorecard.yml` already uses so Dependabot bumps both in lockstep.
- Permissions follow the workflow-permissions PR (#204): top-level `contents: read`, job-level escalation to `security-events: write` only where needed.

## Why

For a public TypeScript MCP server with a Node + Playwright surface, CodeQL is genuinely useful — it catches dataflow issues, prototype pollution, command-injection patterns, etc. that the existing PatternValidator + InputValidator unit tests don't model.

## Test plan

- [x] Workflow file lints (no `actionlint` errors).
- [ ] First run on this PR populates a baseline analysis — review findings before merge.
- [ ] On merge, weekly cron triggers; Scorecard SASTID error clears on next scan.

## Out of scope

Other Scorecard findings tracked separately (see #204 description for the full list and rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)