### PR TITLE
chore(deps): ignore major Node bumps for Dockerfile in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,13 @@ updates:
       actions:
         patterns: ["*"]
   # Docker base image is pinned by SHA — Dependabot bumps the digest when
-  # node:22-alpine moves so the pin doesn't go stale.
+  # node:22-alpine moves so the pin doesn't go stale. Major Node version
+  # bumps are intentional decisions tied to LTS cadence and our CI matrix,
+  # so we ignore them here and bump explicitly in a separate PR.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Tightens Dependabot's `docker` ecosystem to ignore major Node version bumps. Companion to closing #207 (`node:22-alpine` → `26-alpine`).

## Why

- CI doesn't run `docker build`, so a Dependabot "green CI" on a base-image bump only verifies the pin parses — not that the new base image actually works for the project.
- Three Node majors floating across the project today: CI matrix on 22.x, publish workflow on 24.x, Dockerfile on 22-alpine. Letting Dependabot push a 26-alpine bump would make that four. Major-version Docker bumps should be deliberate, tied to LTS cadence, not weekly auto-PRs.

## What still works

Digest moves on `node:22-alpine` still flow through (that's why we added Docker to Dependabot in #204). Only `version-update:semver-major` is blocked. When we want to bump to 24 or 26, we do it explicitly in a focused PR.

## Test plan

- [x] YAML lints (`yq` parse).
- [x] No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)