### PR TITLE
fix(security): resolve js/insecure-temporary-file CodeQL findings (#19, #20)

### DIFF
--- a/src/__tests__/PatternStore.test.ts
+++ b/src/__tests__/PatternStore.test.ts
@@ -8,9 +8,11 @@ describe('PatternStore', () => {
   let testDir: string;
 
   beforeEach(async () => {
-    // Create a temporary directory for testing
-    testDir = path.join(tmpdir(), 'strudel-test-' + Date.now());
-    await fs.mkdir(testDir, { recursive: true });
+    // Create a temporary directory for testing. fs.mkdtemp atomically creates
+    // a uniquely-named directory with an unpredictable random suffix and 0700
+    // permissions, so there is no predictable path an attacker could
+    // pre-create or symlink (unlike tmpdir()+Date.now()).
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'strudel-test-'));
     store = new PatternStore(testDir);
   });
 


### PR DESCRIPTION
Resolves two open CodeQL alerts, both `js/insecure-temporary-file` [high].

## Alert #20 — src/__tests__/PatternStore.test.ts:147
## Alert #19 — src/PatternStore.ts:89

Both alerts share one root cause. The PatternStore test suite built its
scratch directory like this:

```ts
testDir = path.join(tmpdir(), 'strudel-test-' + Date.now());
await fs.mkdir(testDir, { recursive: true });
```

`Date.now()` is predictable, so the resulting path can be guessed and
pre-created by another local user — a classic file-squatting / symlink
attack — and `fs.mkdir` creates the directory with default (world-readable)
permissions.

- **Alert #20** points at `PatternStore.test.ts:147`, the `fs.writeFile`
  that writes a non-JSON fixture file into that predictable directory.
- **Alert #19** points at `PatternStore.ts:89` (`fs.writeFile` in
  `save()`). This is the *interprocedural* sink: CodeQL traced the
  predictable test directory through the `PatternStore` constructor
  (`new PatternStore(testDir)`) into `save()`'s write call.

Production code is **not** affected: `src/server/server.ts:110`
constructs `PatternStore` with the project-relative path `./patterns`,
not an OS temp dir.

## Fix

Replace the predictable path + `fs.mkdir` with a single `fs.mkdtemp` call:

```ts
testDir = await fs.mkdtemp(path.join(tmpdir(), 'strudel-test-'));
```

`fs.mkdtemp` atomically creates a uniquely-named directory with an
unpredictable random suffix and `0700` permissions. This removes the
predictable path, so neither the test's own write nor the write reached
through `PatternStore.save()` lands in an attacker-guessable location —
resolving both alerts at the source.

## Verification

- `npm run build` — pass (tsc + tool-docs generation, no README drift)
- `npx jest src/__tests__/PatternStore.test.ts` — pass (16/16)
- `npm run test:nocov -- --testPathIgnorePatterns=browser` — pass
  (53 suites, 1774 passed, 20 skipped browser)
- `npm run lint` — pass (0 errors; pre-existing `any` warnings only,
  none in the changed file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)