### PR TITLE
feat: add MiniMax music generation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | live-coding-music-mcp
 npm run validate
 ```
 
-You should see a JSON response listing **26 tools**. If you see fewer, the build is out of date — run `npm run build`.
+You should see a JSON response listing **28 tools**. If you see fewer, the build is out of date — run `npm run build`.
 
 ### 4. Make your first sound
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CI](https://github.com/williamzujkowski/live-coding-music-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/live-coding-music-mcp/actions)
 [![npm version](https://img.shields.io/npm/v/@williamzujkowski/live-coding-music-mcp.svg)](https://www.npmjs.com/package/@williamzujkowski/live-coding-music-mcp)
 [![Nerq Trust](https://nerq.ai/badge/live-coding-music-mcp)](https://nerq.ai/kya/live-coding-music-mcp)
-[![Tools](https://img.shields.io/badge/tools-27-green.svg)]()
+[![Tools](https://img.shields.io/badge/tools-28-green.svg)]()
 [![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 A Model Context Protocol (MCP) server that drives [Strudel.cc](https://strudel.cc/) from Claude for AI-assisted live-coding music, pattern generation, and algorithmic composition.
@@ -257,7 +257,7 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 <!-- TOOLS:START -->
 
-**27 tools** across 14 categories:
+**28 tools** across 14 categories:
 
 <details><summary><strong>Setup</strong> (1)</summary>
 
@@ -302,13 +302,14 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 </details>
 
-<details><summary><strong>Generation</strong> (3)</summary>
+<details><summary><strong>Generation</strong> (4)</summary>
 
 | Tool | Description |
 |------|-------------|
 | `compose` | Generate, write, and play a complete pattern in one step. Auto-initializes default browser if needed. |
 | `generate_part` | Generate a single instrumental layer and append it to the current session pattern.  |
 | `generate_rhythm` | Generate a rhythmic pattern and append it to the current session.  |
+| `generate_music` | Generate music with the MiniMax music API and return the generated audio as a URL or hexadecimal payload. |
 
 </details>
 
@@ -384,7 +385,7 @@ compose with style: "dnb", key: "Am", tempo: 174, auto_play: true
 
 </details>
 
-_Auto-generated from source. 27 tools registered._
+_Auto-generated from source. 28 tools registered._
 
 <!-- TOOLS:END -->
 

--- a/scripts/generate-tool-docs.ts
+++ b/scripts/generate-tool-docs.ts
@@ -81,7 +81,7 @@ function categorizeTools(tools: Tool[]): Map<string, Tool[]> {
     playback: 'Playback', set_tempo: 'Playback',
     pattern_store: 'Storage', import_midi: 'Storage',
     history: 'History',
-    compose: 'Generation', generate_part: 'Generation', generate_rhythm: 'Generation',
+    compose: 'Generation', generate_part: 'Generation', generate_rhythm: 'Generation', generate_music: 'Generation',
     music_theory: 'Music Theory',
     transform: 'Transform', effect: 'Transform', shape: 'Transform',
     ai_assist: 'AI',

--- a/src/__tests__/unit/MiniMaxMusicService.test.ts
+++ b/src/__tests__/unit/MiniMaxMusicService.test.ts
@@ -1,0 +1,129 @@
+import {
+  MiniMaxMusicService,
+  type MiniMaxMusicRequest,
+} from '../../services/MiniMaxMusicService.js';
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('MiniMaxMusicService', () => {
+  let fetchImpl: jest.Mock;
+  let service: MiniMaxMusicService;
+
+  beforeEach(() => {
+    fetchImpl = jest.fn();
+    service = new MiniMaxMusicService({
+      apiKey: 'unit-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+  });
+
+  it('sends generation fields to the global endpoint and parses URL audio', async () => {
+    fetchImpl.mockResolvedValue(
+      response({
+        base_resp: { status_code: 0 },
+        data: { status: 2, audio: 'https://audio.example/generated.mp3' },
+      })
+    );
+
+    const request: MiniMaxMusicRequest = {
+      model: 'music-3.0',
+      prompt: 'A restrained ambient instrumental',
+      lyrics: 'A quiet night',
+      output_format: 'url',
+      audio_setting: { format: 'mp3', sample_rate: 44100, bitrate: 128000, channel: 2 },
+      lyrics_optimizer: true,
+      is_instrumental: false,
+    };
+    const result = await service.generateMusic(request);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.minimax.io/v1/music_generation',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toEqual({
+      Authorization: 'Bearer unit-key',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(String(init.body))).toEqual(request);
+    expect(result).toEqual({
+      status: 'completed',
+      status_code: 0,
+      audio: 'https://audio.example/generated.mp3',
+      output_format: 'url',
+      audio_format: 'mp3',
+      region: 'global_en',
+      model: 'music-3.0',
+      url_ttl_hours: 24,
+    });
+  });
+
+  it('routes China requests and forwards the regional watermark field', async () => {
+    fetchImpl.mockResolvedValue(
+      response({
+        base_resp: { status_code: 0 },
+        data: { status: 2, audio: 'ab12' },
+      })
+    );
+
+    await service.generateMusic({
+      model: 'music-2.6',
+      region: 'cn_zh',
+      output_format: 'hex',
+      aigc_watermark: true,
+    });
+
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://api.minimaxi.com/v1/music_generation');
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: 'music-2.6',
+      output_format: 'hex',
+      aigc_watermark: true,
+    });
+  });
+
+  it('combines streamed hexadecimal audio chunks and parses SSE framing', async () => {
+    fetchImpl.mockResolvedValue(
+      new Response(
+        [
+          `data: ${JSON.stringify({ data: { status: 1, audio: 'ab' } })}`,
+          `data: ${JSON.stringify({ data: { status: 2, audio: 'cd' }, base_resp: { status_code: 0 } })}`,
+          'data: [DONE]',
+        ].join('\n')
+      )
+    );
+
+    const result = await service.generateMusic({ model: 'music-3.0', stream: true });
+
+    expect(result.status).toBe('completed');
+    expect(result.output_format).toBe('hex');
+    expect(result.audio).toBe('abcd');
+  });
+
+  it('rejects URL output for streaming requests', async () => {
+    await expect(
+      service.generateMusic({ model: 'music-3.0', stream: true, output_format: 'url' })
+    ).rejects.toThrow('only supports hexadecimal output');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects the regional watermark on the global endpoint', async () => {
+    await expect(
+      service.generateMusic({ model: 'music-3.0', aigc_watermark: true })
+    ).rejects.toThrow('only supported for the China music endpoint');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a non-zero API status code', async () => {
+    fetchImpl.mockResolvedValue(
+      response({
+        base_resp: { status_code: 1004, status_msg: 'invalid request' },
+        data: { status: 2 },
+      })
+    );
+
+    await expect(service.generateMusic({ model: 'music-3.0' })).rejects.toThrow('invalid request');
+  });
+});

--- a/src/__tests__/unit/MusicGenerationTool.test.ts
+++ b/src/__tests__/unit/MusicGenerationTool.test.ts
@@ -1,0 +1,47 @@
+import { execute, tools } from '../../server/tools/music.js';
+import type { ToolContext } from '../../server/tools/types.js';
+
+describe('generate_music tool', () => {
+  it('exposes the generation models, output formats, and audio formats', () => {
+    const tool = tools[0];
+    const schema = tool?.inputSchema as any;
+
+    expect(tool?.name).toBe('generate_music');
+    expect(schema.required).toEqual(['model']);
+    expect(schema.properties.model.enum).toEqual([
+      'music-3.0',
+      'music-2.6',
+      'music-3.0-free',
+      'music-2.6-free',
+    ]);
+    expect(schema.properties.output_format.enum).toEqual(['url', 'hex']);
+    expect(schema.properties.audio_setting.properties.format.enum).toEqual(['mp3', 'wav', 'pcm']);
+  });
+
+  it('forwards the request to the injected service', async () => {
+    const generateMusic = jest.fn().mockResolvedValue({
+      status: 'completed',
+      status_code: 0,
+      audio: 'feed',
+      output_format: 'hex',
+      region: 'global_en',
+      model: 'music-3.0',
+    });
+    const ctx = { miniMaxMusicService: { generateMusic } } as unknown as ToolContext;
+    const args = {
+      model: 'music-3.0',
+      prompt: 'A bright instrumental',
+      stream: true,
+      output_format: 'hex',
+      audio_setting: { format: 'wav' },
+      lyrics_optimizer: false,
+      is_instrumental: true,
+      region: 'global_en',
+    };
+
+    const result = await execute('generate_music', args, ctx);
+
+    expect(generateMusic).toHaveBeenCalledWith(args);
+    expect(result).toEqual(expect.objectContaining({ audio: 'feed', status: 'completed' }));
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -12,6 +12,7 @@ import { PatternStore } from '../PatternStore.js';
 import { MusicTheory } from '../services/MusicTheory.js';
 import { PatternGenerator } from '../services/PatternGenerator.js';
 import { GeminiService } from '../services/GeminiService.js';
+import { MiniMaxMusicService } from '../services/MiniMaxMusicService.js';
 import { AudioCaptureService } from '../services/AudioCaptureService.js';
 import { MIDIExportService } from '../services/MIDIExportService.js';
 import { MIDIImportService } from '../services/MIDIImportService.js';
@@ -32,6 +33,7 @@ import { sessionModule } from './tools/session.js';
 import { captureModule } from './tools/capture.js';
 import { aiModule } from './tools/ai.js';
 import { composeModule } from './tools/compose.js';
+import { musicModule } from './tools/music.js';
 import type { Envelope, ToolContext, HistoryEntry } from './tools/types.js';
 import { categorizeError, err, isEnvelope, ok } from './tools/types.js';
 import { readResource, resources as mcpResources } from './resources.js';
@@ -61,6 +63,7 @@ export class StrudelMCPServer {
   private theory: MusicTheory;
   private generator: PatternGenerator;
   private geminiService: GeminiService;
+  private miniMaxMusicService: MiniMaxMusicService;
   /**
    * Per-session AudioCaptureService instances (#180). Keyed by session id
    * (or 'default' for the legacy/single-session path). Each session's
@@ -111,6 +114,7 @@ export class StrudelMCPServer {
     this.theory = new MusicTheory();
     this.generator = new PatternGenerator();
     this.geminiService = new GeminiService();
+    this.miniMaxMusicService = new MiniMaxMusicService();
     this.midiExportService = new MIDIExportService();
     this.midiImportService = new MIDIImportService();
     this.sessionManager = new SessionManager(config.headless, audioAnalysisConfig);
@@ -131,6 +135,7 @@ export class StrudelMCPServer {
       ...playbackModule.tools,
       ...transformModule.tools,
       ...generateModule.tools,
+      ...musicModule.tools,
       ...analysisModule.tools,
       ...storageModule.tools,
       ...historyModule.tools,
@@ -366,6 +371,7 @@ export class StrudelMCPServer {
       theory: this.theory,
       sessionManager: this.sessionManager,
       geminiService: this.geminiService,
+      miniMaxMusicService: this.miniMaxMusicService,
       strudelEngine: this.strudelEngine,
       midiExportService: this.midiExportService,
       midiImportService: this.midiImportService,
@@ -412,6 +418,9 @@ export class StrudelMCPServer {
     }
     if (generateModule.toolNames.has(name)) {
       return await generateModule.execute(name, args, ctx);
+    }
+    if (musicModule.toolNames.has(name)) {
+      return await musicModule.execute(name, args, ctx);
     }
     if (sessionModule.toolNames.has(name)) {
       return await sessionModule.execute(name, args, ctx);

--- a/src/server/tools/music.ts
+++ b/src/server/tools/music.ts
@@ -1,0 +1,95 @@
+/**
+ * music domain — remote music generation that returns an audio payload.
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  MINIMAX_MUSIC_AUDIO_FORMATS,
+  MINIMAX_MUSIC_MODELS,
+  MINIMAX_MUSIC_OUTPUT_FORMATS,
+  MiniMaxMusicService,
+} from '../../services/MiniMaxMusicService.js';
+import type { ToolContext, ToolModule } from './types.js';
+
+export const tools: Tool[] = [
+  {
+    name: 'generate_music',
+    description:
+      'Generate music with the MiniMax music API and return the generated audio as a URL or hexadecimal payload.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        model: {
+          type: 'string',
+          enum: [...MINIMAX_MUSIC_MODELS],
+          description: 'Music generation model.',
+        },
+        prompt: {
+          type: 'string',
+          description: 'Natural-language description of the music to generate.',
+        },
+        lyrics: { type: 'string', description: 'Lyrics for the generated song.' },
+        stream: { type: 'boolean', description: 'Return streamed hexadecimal audio chunks.' },
+        output_format: {
+          type: 'string',
+          enum: [...MINIMAX_MUSIC_OUTPUT_FORMATS],
+          description: 'Completed response format. Streaming supports hexadecimal output only.',
+        },
+        audio_setting: {
+          type: 'object',
+          description: 'Optional audio settings. The format can be mp3, wav, or pcm.',
+          properties: {
+            format: {
+              type: 'string',
+              enum: [...MINIMAX_MUSIC_AUDIO_FORMATS],
+              description: 'Audio encoding.',
+            },
+            sample_rate: { type: 'integer', description: 'Audio sample rate.' },
+            bitrate: { type: 'integer', description: 'Audio bitrate.' },
+            channel: { type: 'integer', description: 'Audio channel count.' },
+          },
+          additionalProperties: true,
+        },
+        lyrics_optimizer: {
+          type: 'boolean',
+          description: 'Optimize supplied lyrics before generation.',
+        },
+        is_instrumental: {
+          type: 'boolean',
+          description: 'Generate an instrumental track without vocals.',
+        },
+        region: {
+          type: 'string',
+          enum: ['global_en', 'cn_zh'],
+          description: 'API region. Defaults to global_en; cn_zh supports aigc_watermark.',
+        },
+        aigc_watermark: { type: 'boolean', description: 'China-region watermark option.' },
+      },
+      required: ['model'],
+    },
+  },
+];
+
+export const toolNames = new Set(tools.map((tool) => tool.name));
+
+export async function execute(name: string, args: any, ctx: ToolContext): Promise<unknown> {
+  if (name !== 'generate_music') {
+    throw new Error(`music module does not handle tool: ${name}`);
+  }
+
+  const service = ctx.miniMaxMusicService ?? new MiniMaxMusicService();
+  return await service.generateMusic({
+    model: args?.model,
+    prompt: args?.prompt,
+    lyrics: args?.lyrics,
+    stream: args?.stream,
+    output_format: args?.output_format,
+    audio_setting: args?.audio_setting,
+    lyrics_optimizer: args?.lyrics_optimizer,
+    is_instrumental: args?.is_instrumental,
+    region: args?.region,
+    aigc_watermark: args?.aigc_watermark,
+  });
+}
+
+export const musicModule: ToolModule = { tools, toolNames, execute };

--- a/src/server/tools/types.ts
+++ b/src/server/tools/types.ts
@@ -17,6 +17,7 @@ import type { MIDIExportService } from '../../services/MIDIExportService.js';
 import type { MIDIImportService } from '../../services/MIDIImportService.js';
 import type { AudioCaptureService } from '../../services/AudioCaptureService.js';
 import type { GeminiService } from '../../services/GeminiService.js';
+import type { MiniMaxMusicService } from '../../services/MiniMaxMusicService.js';
 import type { StrudelEngine } from '../../services/StrudelEngine.js';
 import type { Logger } from '../../utils/Logger.js';
 import type { PerformanceMonitor } from '../../utils/PerformanceMonitor.js';
@@ -57,6 +58,8 @@ export interface ToolContext {
   theory: MusicTheory;
   sessionManager: SessionManager;
   geminiService: GeminiService;
+  /** Optional injection point for the remote music-generation service. */
+  miniMaxMusicService?: MiniMaxMusicService;
   strudelEngine: StrudelEngine;
   midiExportService: MIDIExportService;
   midiImportService: MIDIImportService;

--- a/src/services/MiniMaxMusicService.ts
+++ b/src/services/MiniMaxMusicService.ts
@@ -1,0 +1,290 @@
+export const MINIMAX_MUSIC_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/music_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/music_generation',
+} as const;
+
+export const MINIMAX_MUSIC_MODELS = [
+  'music-3.0',
+  'music-2.6',
+  'music-3.0-free',
+  'music-2.6-free',
+] as const;
+
+export const MINIMAX_MUSIC_OUTPUT_FORMATS = ['url', 'hex'] as const;
+export const MINIMAX_MUSIC_AUDIO_FORMATS = ['mp3', 'wav', 'pcm'] as const;
+
+export type MiniMaxMusicRegion = keyof typeof MINIMAX_MUSIC_ENDPOINTS;
+export type MiniMaxMusicModel = (typeof MINIMAX_MUSIC_MODELS)[number];
+export type MiniMaxMusicOutputFormat = (typeof MINIMAX_MUSIC_OUTPUT_FORMATS)[number];
+export type MiniMaxMusicAudioFormat = (typeof MINIMAX_MUSIC_AUDIO_FORMATS)[number];
+
+export interface MiniMaxAudioSetting {
+  format?: MiniMaxMusicAudioFormat;
+  sample_rate?: number;
+  bitrate?: number;
+  channel?: number;
+  [key: string]: unknown;
+}
+
+export interface MiniMaxMusicRequest {
+  model: MiniMaxMusicModel;
+  prompt?: string;
+  lyrics?: string;
+  stream?: boolean;
+  output_format?: MiniMaxMusicOutputFormat;
+  audio_setting?: MiniMaxAudioSetting;
+  lyrics_optimizer?: boolean;
+  is_instrumental?: boolean;
+  region?: MiniMaxMusicRegion;
+  aigc_watermark?: boolean;
+}
+
+export interface MiniMaxMusicResult {
+  status: 'in_progress' | 'completed';
+  status_code: number;
+  audio: string;
+  output_format: MiniMaxMusicOutputFormat;
+  audio_format?: MiniMaxMusicAudioFormat;
+  region: MiniMaxMusicRegion;
+  model: MiniMaxMusicModel;
+  url_ttl_hours?: number;
+}
+
+interface MiniMaxMusicResponse {
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+  data?: {
+    status?: number;
+    audio?: string;
+  };
+}
+
+export interface MiniMaxMusicServiceOptions {
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === 'string' && values.includes(value as T);
+}
+
+/** Calls the MiniMax music-generation API for both supported regions. */
+export class MiniMaxMusicService {
+  private readonly apiKey: string | undefined;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: MiniMaxMusicServiceOptions = {}) {
+    this.apiKey = options.apiKey ?? process.env.MINIMAX_API_KEY;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  isAvailable(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  /** Generate music and return the API's URL or hexadecimal audio payload. */
+  async generateMusic(request: MiniMaxMusicRequest): Promise<MiniMaxMusicResult> {
+    this.validateRequest(request);
+
+    if (!this.apiKey) {
+      throw new Error('MiniMax API key not configured. Set MINIMAX_API_KEY to generate music.');
+    }
+
+    const region = request.region ?? 'global_en';
+    const response = await this.request(region, this.toPayload(request, region));
+    const payloads = this.parsePayloads(response.body, response.ok, response.status);
+
+    if (!response.ok) {
+      throw new Error(this.formatHttpError(response.status, payloads));
+    }
+
+    const baseResponse = [...payloads]
+      .reverse()
+      .find((payload) => payload.base_resp !== undefined)?.base_resp;
+    if (baseResponse?.status_code !== 0) {
+      throw new Error(
+        `MiniMax music generation failed: ${baseResponse?.status_msg ?? 'unknown API error'}`
+      );
+    }
+
+    const statusCode = [...payloads]
+      .reverse()
+      .find((payload) => typeof payload.data?.status === 'number')?.data?.status;
+    if (statusCode !== 1 && statusCode !== 2) {
+      throw new Error('MiniMax music generation returned an invalid status.');
+    }
+
+    const audioParts = payloads
+      .map((payload) => payload.data?.audio)
+      .filter((audio): audio is string => typeof audio === 'string' && audio.length > 0);
+    const audio = request.stream ? audioParts.join('') : (audioParts.at(-1) ?? '');
+    if (statusCode === 2 && audio.length === 0) {
+      throw new Error('MiniMax music generation completed without audio data.');
+    }
+
+    const outputFormat = request.stream ? 'hex' : (request.output_format ?? 'hex');
+    return {
+      status: statusCode === 2 ? 'completed' : 'in_progress',
+      status_code: baseResponse?.status_code ?? 0,
+      audio,
+      output_format: outputFormat,
+      audio_format: request.audio_setting?.format,
+      region,
+      model: request.model,
+      ...(outputFormat === 'url' ? { url_ttl_hours: 24 } : {}),
+    };
+  }
+
+  private async request(
+    region: MiniMaxMusicRegion,
+    payload: Record<string, unknown>
+  ): Promise<{ body: string; ok: boolean; status: number }> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(MINIMAX_MUSIC_ENDPOINTS[region], {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`MiniMax music generation network request failed: ${message}`);
+    }
+
+    return { body: await response.text(), ok: response.ok, status: response.status };
+  }
+
+  private parsePayloads(body: string, responseOk: boolean, status: number): MiniMaxMusicResponse[] {
+    const trimmed = body.trim();
+    if (trimmed.length === 0) {
+      throw new Error(`MiniMax music generation returned an empty response (HTTP ${status}).`);
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isRecord(parsed)) return [parsed as MiniMaxMusicResponse];
+    } catch {
+      // Streaming responses use one JSON object per data event.
+    }
+
+    const payloads: MiniMaxMusicResponse[] = [];
+    for (const line of trimmed.split(/\r?\n/)) {
+      let data = line.trim();
+      if (data.length === 0 || data.startsWith('event:') || data.startsWith(':')) continue;
+      if (data.startsWith('data:')) data = data.slice('data:'.length).trim();
+      if (data === '[DONE]') continue;
+
+      try {
+        const parsed: unknown = JSON.parse(data);
+        if (isRecord(parsed)) payloads.push(parsed as MiniMaxMusicResponse);
+      } catch {
+        // Ignore framing lines, but reject a response with no JSON payloads below.
+      }
+    }
+
+    if (payloads.length === 0) {
+      throw new Error(
+        responseOk
+          ? 'MiniMax music generation returned an invalid response.'
+          : `MiniMax music generation returned an invalid error response (HTTP ${status}).`
+      );
+    }
+    return payloads;
+  }
+
+  private formatHttpError(status: number, payloads: MiniMaxMusicResponse[]): string {
+    const message = [...payloads].reverse().find((payload) => payload.base_resp?.status_msg)
+      ?.base_resp?.status_msg;
+    return `MiniMax music generation request failed with HTTP ${status}: ${message ?? 'request rejected'}`;
+  }
+
+  private toPayload(
+    request: MiniMaxMusicRequest,
+    region: MiniMaxMusicRegion
+  ): Record<string, unknown> {
+    const payload: Record<string, unknown> = { model: request.model };
+    const optionalFields = [
+      'prompt',
+      'lyrics',
+      'stream',
+      'output_format',
+      'audio_setting',
+      'lyrics_optimizer',
+      'is_instrumental',
+    ] as const;
+
+    for (const field of optionalFields) {
+      if (request[field] !== undefined) payload[field] = request[field];
+    }
+    if (region === 'cn_zh' && request.aigc_watermark !== undefined) {
+      payload.aigc_watermark = request.aigc_watermark;
+    }
+    return payload;
+  }
+
+  private validateRequest(request: MiniMaxMusicRequest): void {
+    if (!isRecord(request)) throw new Error('Music generation request must be an object.');
+    if (!isOneOf(request.model, MINIMAX_MUSIC_MODELS)) {
+      throw new Error(`Invalid music generation model: ${String(request.model)}.`);
+    }
+    if (
+      request.region !== undefined &&
+      !isOneOf(request.region, Object.keys(MINIMAX_MUSIC_ENDPOINTS))
+    ) {
+      throw new Error(`Invalid music generation region: ${String(request.region)}.`);
+    }
+    if (request.prompt !== undefined && typeof request.prompt !== 'string') {
+      throw new Error('Music generation prompt must be a string.');
+    }
+    if (request.lyrics !== undefined && typeof request.lyrics !== 'string') {
+      throw new Error('Music generation lyrics must be a string.');
+    }
+    if (request.stream !== undefined && typeof request.stream !== 'boolean') {
+      throw new Error('Music generation stream must be a boolean.');
+    }
+    if (
+      request.output_format !== undefined &&
+      !isOneOf(request.output_format, MINIMAX_MUSIC_OUTPUT_FORMATS)
+    ) {
+      throw new Error(`Invalid music generation output format: ${String(request.output_format)}.`);
+    }
+    if (request.stream === true && request.output_format === 'url') {
+      throw new Error('Streaming music generation only supports hexadecimal output.');
+    }
+    if (request.audio_setting !== undefined) {
+      if (!isRecord(request.audio_setting))
+        throw new Error('Music generation audio_setting must be an object.');
+      const format = request.audio_setting.format;
+      if (format !== undefined && !isOneOf(format, MINIMAX_MUSIC_AUDIO_FORMATS)) {
+        throw new Error(`Invalid music generation audio format: ${String(format)}.`);
+      }
+      for (const field of ['sample_rate', 'bitrate', 'channel'] as const) {
+        const value = request.audio_setting[field];
+        if (
+          value !== undefined &&
+          (typeof value !== 'number' || !Number.isInteger(value) || value <= 0)
+        ) {
+          throw new Error(`Music generation audio_setting.${field} must be a positive integer.`);
+        }
+      }
+    }
+    for (const field of ['lyrics_optimizer', 'is_instrumental', 'aigc_watermark'] as const) {
+      const value = request[field];
+      if (value !== undefined && typeof value !== 'boolean') {
+        throw new Error(`Music generation ${field} must be a boolean.`);
+      }
+    }
+    if (request.aigc_watermark !== undefined && request.region !== 'cn_zh') {
+      throw new Error('aigc_watermark is only supported for the China music endpoint.');
+    }
+  }
+}


### PR DESCRIPTION
Reason: Add an API-backed music-generation tool that returns generated audio.

## Changes

- Add the `generate_music` MCP tool and `MiniMaxMusicService`.
- Support the global and China endpoints, generation models, request fields, output formats, audio formats, and the China-only watermark option.
- Parse completed JSON responses and streamed data events, returning URL or hexadecimal audio payloads.
- Add focused unit tests and regenerate the README tool catalog.

## Checks

- `npx tsc --noEmit`
- `npm run build`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run test:nocov -- --runInBand src/__tests__/unit/MiniMaxMusicService.test.ts src/__tests__/unit/MusicGenerationTool.test.ts`
- `npm run test:nocov -- --runInBand --testPathIgnorePatterns=browser`
- `npm run validate`
- `git diff --check`
- Secret scan over the complete diff

Browser tests were not run because the local Playwright Chromium executable is not installed.
